### PR TITLE
Fix package names in marker tests

### DIFF
--- a/marker-tests/src/test/kotlin/io/spine/core/jvm/marker/EveryIsOptionRendererSpec.kt
+++ b/marker-tests/src/test/kotlin/io/spine/core/jvm/marker/EveryIsOptionRendererSpec.kt
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spne.core.jvm.marker
+package io.spine.core.jvm.marker
 
 import com.google.protobuf.Message
 import io.kotest.matchers.shouldBe

--- a/marker-tests/src/test/kotlin/io/spine/core/jvm/marker/IsOptionRendererSpec.kt
+++ b/marker-tests/src/test/kotlin/io/spine/core/jvm/marker/IsOptionRendererSpec.kt
@@ -24,38 +24,50 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spne.core.jvm.marker
+package io.spine.core.jvm.marker
 
-import com.google.protobuf.Empty
-import io.spine.tools.core.jvm.PluginTestSetup
-import io.spine.tools.core.jvm.marker.MarkerPlugin
+import io.kotest.matchers.string.shouldContain
 import java.nio.file.Path
+import kotlin.io.path.Path
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 
-/**
- * Abstract base for [MarkerPlugin] tests.
- *
- * The plugin does not have settings.
- *
- * The class exposes properties common for tests based on proto types
- * generated in response to files under `testFixtures/proto/given/types`.
- */
-internal abstract class MarkerPluginTestSetup : PluginTestSetup<Empty>(MarkerPlugin(), "") {
+@DisplayName("`IsOptionRenderer` should")
+internal class IsOptionRendererSpec {
 
-    /**
-     * The directory of the Java package generated for proto types in `animals.proto` and
-     * their siblings of the same "domain".
-     */
-    internal val animalDir = "io/spine/tools/core/jvm/marker/given/animal"
+    companion object : MarkerPluginTestSetup() {
 
-    /**
-     * The package corresponding to [animalDir].
-     */
-    internal val animalPackage = animalDir.replace('/', '.')
+        @BeforeAll
+        @JvmStatic
+        fun setup(@TempDir projectDir: Path) {
+            generateCode(projectDir)
+        }
+    }
 
-    override fun createSettings(projectDir: Path): Empty = Empty.getDefaultInstance()
+    @Test
+    fun `implement an interface via a simple name`() {
+        val javaFiles = files(Path(animalDir), "Unicorn", "Dragon")
 
-    fun generateCode(@TempDir projectDir: Path) {
-        runPipeline(projectDir)
+        javaFiles.forEach {
+            val code = file(it).code()
+            code shouldContain ", Fictional"
+        }
+    }
+
+    @Test
+    fun `implement an interface via a fully qualified name`() {
+        val javaFiles = files(
+            Path("io/spine/tools/core/jvm/marker/given/animal/fiction/greek"),
+            "Pegasus", "Hippalektryon"
+        )
+
+        val qualifiedInterface = "$animalPackage.Fictional"
+
+        javaFiles.forEach {
+            val code = file(it).code()
+            code shouldContain ", $qualifiedInterface"
+        }
     }
 }

--- a/marker-tests/src/test/kotlin/io/spine/core/jvm/marker/MarkerPluginTestSetup.kt
+++ b/marker-tests/src/test/kotlin/io/spine/core/jvm/marker/MarkerPluginTestSetup.kt
@@ -24,50 +24,38 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spne.core.jvm.marker
+package io.spine.core.jvm.marker
 
-import io.kotest.matchers.string.shouldContain
+import com.google.protobuf.Empty
+import io.spine.tools.core.jvm.PluginTestSetup
+import io.spine.tools.core.jvm.marker.MarkerPlugin
 import java.nio.file.Path
-import kotlin.io.path.Path
-import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 
-@DisplayName("`IsOptionRenderer` should")
-internal class IsOptionRendererSpec {
+/**
+ * Abstract base for [MarkerPlugin] tests.
+ *
+ * The plugin does not have settings.
+ *
+ * The class exposes properties common for tests based on proto types
+ * generated in response to files under `testFixtures/proto/given/types`.
+ */
+internal abstract class MarkerPluginTestSetup : PluginTestSetup<Empty>(MarkerPlugin(), "") {
 
-    companion object : MarkerPluginTestSetup() {
+    /**
+     * The directory of the Java package generated for proto types in `animals.proto` and
+     * their siblings of the same "domain".
+     */
+    internal val animalDir = "io/spine/tools/core/jvm/marker/given/animal"
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir projectDir: Path) {
-            generateCode(projectDir)
-        }
-    }
+    /**
+     * The package corresponding to [animalDir].
+     */
+    internal val animalPackage = animalDir.replace('/', '.')
 
-    @Test
-    fun `implement an interface via a simple name`() {
-        val javaFiles = files(Path(animalDir), "Unicorn", "Dragon")
+    override fun createSettings(projectDir: Path): Empty = Empty.getDefaultInstance()
 
-        javaFiles.forEach {
-            val code = file(it).code()
-            code shouldContain ", Fictional"
-        }
-    }
-
-    @Test
-    fun `implement an interface via a fully qualified name`() {
-        val javaFiles = files(
-            Path("io/spine/tools/core/jvm/marker/given/animal/fiction/greek"),
-            "Pegasus", "Hippalektryon"
-        )
-
-        val qualifiedInterface = "$animalPackage.Fictional"
-
-        javaFiles.forEach {
-            val code = file(it).code()
-            code shouldContain ", $qualifiedInterface"
-        }
+    fun generateCode(@TempDir projectDir: Path) {
+        runPipeline(projectDir)
     }
 }


### PR DESCRIPTION
## Summary
- correct package names in marker test sources

## Testing
- `./gradlew test --no-daemon -q` *(fails: cannot find a Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_68553d3628b08333a073ec05cc501596