### PR TITLE
Add missing API documentation

### DIFF
--- a/annotation/src/main/kotlin/io/spine/tools/core/jvm/annotation/PatternAnnotator.kt
+++ b/annotation/src/main/kotlin/io/spine/tools/core/jvm/annotation/PatternAnnotator.kt
@@ -62,5 +62,8 @@ internal abstract class PatternAnnotator : Annotator() {
         patterns.any { it.matches(codeElement) }
 }
 
-internal fun SourceFile<Java>.qualifiedTopClassName(): String
-    = relativePath.toString().replace(File.separator, ".").replace(".java", "")
+/**
+ * Obtains the fully qualified name of the top-level class defined in this file.
+ */
+internal fun SourceFile<Java>.qualifiedTopClassName(): String =
+    relativePath.toString().replace(File.separator, ".").replace(".java", "")

--- a/buildSrc/src/main/kotlin/DokkaExts.kt
+++ b/buildSrc/src/main/kotlin/DokkaExts.kt
@@ -68,11 +68,17 @@ fun DependencyHandlerScope.useDokkaWithSpineExtensions() {
 private fun DependencyHandler.dokkaPlugin(dependencyNotation: Any): Dependency? =
     add("dokkaPlugin", dependencyNotation)
 
+/**
+ * Resolves the directory where Dokka outputs HTML documentation for the given language.
+ */
 internal fun Project.dokkaOutput(language: String): File {
     val lng = language.titleCaseFirstChar()
     return layout.buildDirectory.dir("docs/dokka$lng").get().asFile
 }
 
+/**
+ * Locates a Dokka configuration file under the `buildSrc` resources.
+ */
 fun Project.dokkaConfigFile(file: String): File {
     val dokkaConfDir = project.rootDir.resolve("buildSrc/src/main/resources/dokka")
     return dokkaConfDir.resolve(file)

--- a/ksp/src/main/kotlin/io/spine/tools/core/jvm/ksp/gradle/KspGradlePlugin.kt
+++ b/ksp/src/main/kotlin/io/spine/tools/core/jvm/ksp/gradle/KspGradlePlugin.kt
@@ -42,6 +42,9 @@ public object KspGradlePlugin {
      */
     public const val id: String = "com.google.devtools.ksp"
 
+    /**
+     * Obtains the path to the directory where KSP generates sources for the given [project].
+     */
     public fun defaultTargetDirectory(project: Project): Path {
         val generatedDir = project.layout.buildDirectory.dir("generated")
         return generatedDir.get().asFile.toPath()


### PR DESCRIPTION
## Summary
- document internal `qualifiedTopClassName` extension
- document Dokka helper functions
- document KSP plugin default target directory

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68587e15c99c8333ab2f80fc080dcca7