### PR TITLE
Bump Validation and CoreJvm Compiler

### DIFF
--- a/.agents/coding-guidelines.md
+++ b/.agents/coding-guidelines.md
@@ -21,10 +21,12 @@
 - **Generic parameters** over explicit variable types (`val list = mutableList<Dependency>()`)  
 - **Java interop annotations** only when needed (`@file:JvmName`, `@JvmStatic`)
 - **Kotlin DSL** for Gradle files
+- **Kotlin Protobuf DSL** (`myMessage { field = value }`) over Java builder chains
 
 ### ❌ Avoid
 - Mutable data structures
 - Java-style verbosity (builders with setters)
+- Java Protobuf builders in Kotlin code (`newBuilder()`, `toBuilder()`) unless interop requires them
 - Redundant null checks (`?.let` misuse)
 - Using `!!` unless clearly justified
 - Type names in variable names (`userObject`, `itemList`)

--- a/.agents/documentation-guidelines.md
+++ b/.agents/documentation-guidelines.md
@@ -6,6 +6,11 @@
 - When using TODO comments, follow the format on the [dedicated page][todo-comments].
 - File and directory names should be formatted as code.
 
+## Protobuf file headers
+- In `.proto` files, a multi-paragraph documentation header must end with a
+  trailing empty comment line (`//`).
+- Single-paragraph headers do not require the trailing empty comment line.
+
 ## Avoid widows, runts, orphans, or rivers
 
 Agents should **AVOID** text flow patters illustrated

--- a/.agents/skills/kotlin-review/SKILL.md
+++ b/.agents/skills/kotlin-review/SKILL.md
@@ -32,6 +32,7 @@ live in `.agents/`:
    nullability, and idiomatic refactors require surrounding context.
 3. Check against `.agents/coding-guidelines.md`:
    - Kotlin idioms (extension functions, `when`, smart casts, data/sealed classes).
+   - Kotlin Protobuf DSL (`message { ... }`) preferred over Java builders (`newBuilder()`, `toBuilder()`) in Kotlin.
    - Immutability by default.
    - No `!!` without justification.
    - No type names in variable names.

--- a/.agents/skills/review-docs/SKILL.md
+++ b/.agents/skills/review-docs/SKILL.md
@@ -34,6 +34,7 @@ The authoritative standards live in `.agents/`:
    `git diff <base>...HEAD` depending on what the user describes. Restrict
    to files matching:
    - `**/*.kt`, `**/*.kts`, `**/*.java` (for KDoc/Javadoc inside sources)
+   - `**/*.proto` (for file-level documentation headers)
    - `**/*.md` (Markdown docs)
    Do **not** review the full repo — only what changed.
    Filter out config-distributed files (see `AGENTS.md § Code review` for the
@@ -68,6 +69,9 @@ The authoritative standards live in `.agents/`:
   `// TODO: …` without owner/issue reference is a Should-fix.
 - **File and directory names rendered as code.** Within KDoc/Javadoc prose,
   `path/to/file.kt` and `module-name` must use backticks.
+- **Multi-paragraph Protobuf headers end with an empty comment line.** In
+  `.proto` files, if the file-level documentation header has more than one
+  paragraph, it must end with a trailing empty comment line (`//`).
 
 ### B. Markdown docs
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,8 +15,11 @@ Additional guidelines are in `.agents/` — see `.agents/_TOC.md` for the index
 
 ## Do not review
 
-If the current repository is `config`, review these files normally: they are
-authoritative there. In other repositories, the following files are managed by
+Never review `gradlew` or `gradlew.bat` in any repository, including `config`.
+These files are provided by Gradle and are not edited manually.
+
+If the current repository is `config`, review its files normally unless noted
+above: they are authoritative there. In other repositories, the following files are managed by
 the `config` submodule and must be reviewed in the `config` repository, not
 here. In those consumer repositories, skip them without comment:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,9 @@ Ruthlessly iterate until mistakes stop repeating.
 
 ## Code review
 
+Never review `gradlew` or `gradlew.bat` in any repository, including `config`.
+These files are provided by Gradle and are not edited manually.
+
 When reviewing a pull request or diff in a consumer repository, skip any
 file that the `config` module distributes. Those files belong in a review
 of the `config` repo, not the consumer repo — reviewing them there adds
@@ -87,7 +90,7 @@ noise without value.
 
 Do **not** apply this skip rule when reviewing the `config` repository
 itself. In `config`, these files are source files owned by the current
-repo and must be reviewed normally.
+repo and must be reviewed normally, except `gradlew` and `gradlew.bat`.
 
 In consumer repositories, skip without comment any path matching:
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,7 @@ buildscript {
                     base.annotations,
                     base.libForBuildScript,
                     base.environment,
+                    base.format,
                     io.spine.dependency.local.Reflect.lib,
                     toolBase.lib,
                     coreJava.server,

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
@@ -46,7 +46,7 @@ object CoreJvmCompiler {
     /**
      * The version used in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.065"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.066"
 
     /**
      * The version to be used for integration tests.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.443"
+    const val version = "2.0.0-SNAPSHOT.444"
 
     /**
      * The last version of Validation compatible with ProtoData.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -46,7 +46,8 @@ object Validation {
     const val group = Spine.toolsGroup
     private const val prefix = "validation"
 
-    const val gradlePluginLib = "$group:$prefix-gradle-plugin:$version"
+    const val gradlePluginModule = "$group:$prefix-gradle-plugin"
+    const val gradlePluginLib = "$gradlePluginModule:$version"
 
     const val runtimeModule = "${Spine.group}:spine-$prefix-jvm-runtime"
 

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1151,7 +1151,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
+This report was generated on **Thu May 28 18:22:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2317,7 +2317,7 @@ This report was generated on **Thu May 28 18:13:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
+This report was generated on **Thu May 28 18:22:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3475,7 +3475,7 @@ This report was generated on **Thu May 28 18:13:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
+This report was generated on **Thu May 28 18:22:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4444,7 +4444,7 @@ This report was generated on **Thu May 28 18:13:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
+This report was generated on **Thu May 28 18:22:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5602,7 +5602,7 @@ This report was generated on **Thu May 28 18:13:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
+This report was generated on **Thu May 28 18:22:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6571,7 +6571,7 @@ This report was generated on **Thu May 28 18:13:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
+This report was generated on **Thu May 28 18:22:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -7700,7 +7700,7 @@ This report was generated on **Thu May 28 18:13:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
+This report was generated on **Thu May 28 18:22:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -8921,7 +8921,7 @@ This report was generated on **Thu May 28 18:13:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
+This report was generated on **Thu May 28 18:22:52 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -10087,7 +10087,7 @@ This report was generated on **Thu May 28 18:13:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
+This report was generated on **Thu May 28 18:22:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -11056,7 +11056,7 @@ This report was generated on **Thu May 28 18:13:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
+This report was generated on **Thu May 28 18:22:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -12222,7 +12222,7 @@ This report was generated on **Thu May 28 18:13:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
+This report was generated on **Thu May 28 18:22:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -13191,7 +13191,7 @@ This report was generated on **Thu May 28 18:13:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
+This report was generated on **Thu May 28 18:22:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -14428,7 +14428,7 @@ This report was generated on **Thu May 28 18:13:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
+This report was generated on **Thu May 28 18:22:52 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -15686,7 +15686,7 @@ This report was generated on **Thu May 28 18:13:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 28 18:13:36 WEST 2026** using 
+This report was generated on **Thu May 28 18:22:52 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -16373,7 +16373,7 @@ This report was generated on **Thu May 28 18:13:36 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 28 18:13:30 WEST 2026** using 
+This report was generated on **Thu May 28 18:22:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -17539,7 +17539,7 @@ This report was generated on **Thu May 28 18:13:30 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
+This report was generated on **Thu May 28 18:22:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -18508,7 +18508,7 @@ This report was generated on **Thu May 28 18:13:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 28 18:13:32 WEST 2026** using 
+This report was generated on **Thu May 28 18:22:53 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -19674,7 +19674,7 @@ This report was generated on **Thu May 28 18:13:32 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 28 18:13:32 WEST 2026** using 
+This report was generated on **Thu May 28 18:22:53 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -20643,6 +20643,6 @@ This report was generated on **Thu May 28 18:13:32 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 28 18:13:32 WEST 2026** using 
+This report was generated on **Thu May 28 18:22:53 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:core-jvm-annotation:2.0.0-SNAPSHOT.066`
+# Dependencies of `io.spine.tools:core-jvm-annotation:2.0.0-SNAPSHOT.067`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -1151,14 +1151,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 27 22:08:56 WEST 2026** using 
+This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-base:2.0.0-SNAPSHOT.066`
+# Dependencies of `io.spine.tools:core-jvm-base:2.0.0-SNAPSHOT.067`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -2317,14 +2317,14 @@ This report was generated on **Wed May 27 22:08:56 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 27 22:08:56 WEST 2026** using 
+This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-comparable:2.0.0-SNAPSHOT.066`
+# Dependencies of `io.spine.tools:core-jvm-comparable:2.0.0-SNAPSHOT.067`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -3475,14 +3475,14 @@ This report was generated on **Wed May 27 22:08:56 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 27 22:08:56 WEST 2026** using 
+This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-comparable-tests:2.0.0-SNAPSHOT.066`
+# Dependencies of `io.spine.tools:core-jvm-comparable-tests:2.0.0-SNAPSHOT.067`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4444,14 +4444,14 @@ This report was generated on **Wed May 27 22:08:56 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 27 22:08:56 WEST 2026** using 
+This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-entity:2.0.0-SNAPSHOT.066`
+# Dependencies of `io.spine.tools:core-jvm-entity:2.0.0-SNAPSHOT.067`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -5602,14 +5602,14 @@ This report was generated on **Wed May 27 22:08:56 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 27 22:08:56 WEST 2026** using 
+This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-entity-tests:2.0.0-SNAPSHOT.066`
+# Dependencies of `io.spine.tools:core-jvm-entity-tests:2.0.0-SNAPSHOT.067`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6571,14 +6571,14 @@ This report was generated on **Wed May 27 22:08:56 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 27 22:08:56 WEST 2026** using 
+This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-grpc:2.0.0-SNAPSHOT.066`
+# Dependencies of `io.spine.tools:core-jvm-grpc:2.0.0-SNAPSHOT.067`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -7700,14 +7700,14 @@ This report was generated on **Wed May 27 22:08:56 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 27 22:08:56 WEST 2026** using 
+This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-ksp:2.0.0-SNAPSHOT.066`
+# Dependencies of `io.spine.tools:core-jvm-ksp:2.0.0-SNAPSHOT.067`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -8921,14 +8921,14 @@ This report was generated on **Wed May 27 22:08:56 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 27 22:08:57 WEST 2026** using 
+This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-marker:2.0.0-SNAPSHOT.066`
+# Dependencies of `io.spine.tools:core-jvm-marker:2.0.0-SNAPSHOT.067`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -10087,14 +10087,14 @@ This report was generated on **Wed May 27 22:08:57 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 27 22:08:56 WEST 2026** using 
+This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-marker-tests:2.0.0-SNAPSHOT.066`
+# Dependencies of `io.spine.tools:core-jvm-marker-tests:2.0.0-SNAPSHOT.067`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -11056,14 +11056,14 @@ This report was generated on **Wed May 27 22:08:56 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 27 22:08:56 WEST 2026** using 
+This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-message-group:2.0.0-SNAPSHOT.066`
+# Dependencies of `io.spine.tools:core-jvm-message-group:2.0.0-SNAPSHOT.067`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -12222,14 +12222,14 @@ This report was generated on **Wed May 27 22:08:56 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 27 22:08:56 WEST 2026** using 
+This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-message-group-tests:2.0.0-SNAPSHOT.066`
+# Dependencies of `io.spine.tools:core-jvm-message-group-tests:2.0.0-SNAPSHOT.067`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -13191,14 +13191,14 @@ This report was generated on **Wed May 27 22:08:56 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 27 22:08:56 WEST 2026** using 
+This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-plugins:2.0.0-SNAPSHOT.066`
+# Dependencies of `io.spine.tools:core-jvm-plugins:2.0.0-SNAPSHOT.067`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -14428,14 +14428,14 @@ This report was generated on **Wed May 27 22:08:56 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 27 22:08:57 WEST 2026** using 
+This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-routing:2.0.0-SNAPSHOT.066`
+# Dependencies of `io.spine.tools:core-jvm-routing:2.0.0-SNAPSHOT.067`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -15686,14 +15686,14 @@ This report was generated on **Wed May 27 22:08:57 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 27 22:08:57 WEST 2026** using 
+This report was generated on **Thu May 28 18:13:36 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-routing-tests:2.0.0-SNAPSHOT.066`
+# Dependencies of `io.spine.tools:core-jvm-routing-tests:2.0.0-SNAPSHOT.067`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -16373,14 +16373,14 @@ This report was generated on **Wed May 27 22:08:57 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 27 22:08:56 WEST 2026** using 
+This report was generated on **Thu May 28 18:13:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-signal:2.0.0-SNAPSHOT.066`
+# Dependencies of `io.spine.tools:core-jvm-signal:2.0.0-SNAPSHOT.067`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -17539,14 +17539,14 @@ This report was generated on **Wed May 27 22:08:56 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 27 22:08:56 WEST 2026** using 
+This report was generated on **Thu May 28 18:13:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-signal-tests:2.0.0-SNAPSHOT.066`
+# Dependencies of `io.spine.tools:core-jvm-signal-tests:2.0.0-SNAPSHOT.067`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -18508,14 +18508,14 @@ This report was generated on **Wed May 27 22:08:56 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 27 22:08:57 WEST 2026** using 
+This report was generated on **Thu May 28 18:13:32 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-uuid:2.0.0-SNAPSHOT.066`
+# Dependencies of `io.spine.tools:core-jvm-uuid:2.0.0-SNAPSHOT.067`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -19674,14 +19674,14 @@ This report was generated on **Wed May 27 22:08:57 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 27 22:08:57 WEST 2026** using 
+This report was generated on **Thu May 28 18:13:32 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-uuid-tests:2.0.0-SNAPSHOT.066`
+# Dependencies of `io.spine.tools:core-jvm-uuid-tests:2.0.0-SNAPSHOT.067`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -20643,6 +20643,6 @@ This report was generated on **Wed May 27 22:08:57 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 27 22:08:57 WEST 2026** using 
+This report was generated on **Thu May 28 18:13:32 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>core-jvm-compiler</artifactId>
-<version>2.0.0-SNAPSHOT.066</version>
+<version>2.0.0-SNAPSHOT.067</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -92,7 +92,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-validation-jvm-runtime</artifactId>
-    <version>2.0.0-SNAPSHOT.443</version>
+    <version>2.0.0-SNAPSHOT.444</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -164,13 +164,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>validation-context</artifactId>
-    <version>2.0.0-SNAPSHOT.443</version>
+    <version>2.0.0-SNAPSHOT.444</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>validation-gradle-plugin</artifactId>
-    <version>2.0.0-SNAPSHOT.443</version>
+    <version>2.0.0-SNAPSHOT.444</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -254,7 +254,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>validation-java</artifactId>
-    <version>2.0.0-SNAPSHOT.443</version>
+    <version>2.0.0-SNAPSHOT.444</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -382,7 +382,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>core-jvm-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.065</version>
+    <version>2.0.0-SNAPSHOT.066</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -407,12 +407,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>time-validation</artifactId>
-    <version>2.0.0-SNAPSHOT.240</version>
+    <version>2.0.0-SNAPSHOT.242</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>validation-java-bundle</artifactId>
-    <version>2.0.0-SNAPSHOT.443</version>
+    <version>2.0.0-SNAPSHOT.444</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,5 +29,5 @@
  *
  * Do not rename this property, as it is also used in the integration tests via its name.
  */
-val coreJvmCompilerVersion by extra("2.0.0-SNAPSHOT.066")
+val coreJvmCompilerVersion by extra("2.0.0-SNAPSHOT.067")
 val versionToPublish by extra(coreJvmCompilerVersion)


### PR DESCRIPTION
This PR bumps the mentioned two dependencies so that latest Validation Compiler and Gradle plugin could be allied in the consumer projects.