### PR TITLE
Adopt `MessageFile` moved from `base-libraries`

### DIFF
--- a/.agents/tasks/move-message-file-to-core-jvm-compiler.md
+++ b/.agents/tasks/move-message-file-to-core-jvm-compiler.md
@@ -1,0 +1,60 @@
+---
+slug: move-message-file-to-core-jvm-compiler
+branch: claude/cool-lamport-rnwzpu
+owner: claude
+status: in-progress
+started: 2026-06-10
+---
+
+## Goal
+
+Host the `MessageFile` enum (moved out of `io.spine.base` in `base-libraries`,
+see [base-libraries#941](https://github.com/SpineEventEngine/base-libraries/issues/941))
+in `core-jvm-base` under `io.spine.tools.core.jvm`, converted to Kotlin, with
+all in-repo consumers switched to the new type and the ported unit test green.
+
+## Context
+
+- The enum encodes the codegen file-naming convention
+  (`commands.proto`, `events.proto`, `rejections.proto`); its only org-wide
+  production consumer is `CoreJvmCompilerSettings` in the `base` module here.
+- Strategy: **coordinated hard move** (no shim), per the precedent of
+  `move-fs-dir-types-to-tool-base` in `base-libraries`.
+- This PR is self-contained: the new enum lives in
+  `io.spine.tools.core.jvm`, so it does not clash with
+  `io.spine.base.MessageFile` still present in the pinned published
+  `spine-base`. When the `Base` dependency is bumped past the removal later,
+  nothing here will reference the old class anymore.
+- The enum's dependency `io.spine.code.proto.FileName` stays in `spine-base`,
+  which `core-jvm-base` already has as an `api` dependency.
+- Consumers to update (all in this repo):
+  - `base`: `CoreJvmCompilerSettings.kt` (production).
+  - `plugins`: `CoreJvmOptionsSpec.kt` (test).
+  - `signal-tests`: `SignalPluginTestSetup.kt`, `SignalDiscoverySpec.kt` (tests).
+
+## Plan
+
+- [x] Add `base/src/main/kotlin/io/spine/tools/core/jvm/MessageFile.kt` —
+      Kotlin conversion of the Java original (`suffix` becomes a `val`,
+      `Predicate<FileDescriptorProto>` retained).
+- [x] Switch the four consumer files to the new import and the
+      `suffix` property.
+- [x] Port `MessageFileTest.java` →
+      `base/src/test/kotlin/io/spine/tools/core/jvm/MessageFileSpec.kt`
+      (Kotest assertions; synthetic `FileDescriptorProto` instead of the
+      test-only proto file used in `base-libraries`; added a test pinning
+      the conventional suffix values).
+- [x] Bump `version.gradle.kts` → `2.0.0-SNAPSHOT.069`; project version
+      strings in `docs/dependencies/*` updated to match (no dependency
+      changed, so the regenerated content differs only in those strings).
+- [ ] Build the affected modules and run the tests — **blocked locally**:
+      the remote session's network policy returns 403 for the Spine
+      artifact repositories, so Gradle cannot resolve the SDK snapshot
+      dependencies. Verification delegated to PR CI.
+- [x] Commit, push, draft PR referencing base-libraries#941.
+
+## Log
+
+- 2026-06-10 — drafted; executing (work authorized by the issue assignment).
+- 2026-06-10 — sources done; local Gradle build impossible (403 from all
+  Spine repos under the session network policy); relying on PR CI.

--- a/.agents/tasks/move-message-file-to-core-jvm-compiler.md
+++ b/.agents/tasks/move-message-file-to-core-jvm-compiler.md
@@ -2,7 +2,7 @@
 slug: move-message-file-to-core-jvm-compiler
 branch: claude/cool-lamport-rnwzpu
 owner: claude
-status: in-progress
+status: ready-for-review
 started: 2026-06-10
 ---
 
@@ -47,10 +47,11 @@ all in-repo consumers switched to the new type and the ported unit test green.
 - [x] Bump `version.gradle.kts` → `2.0.0-SNAPSHOT.069`; project version
       strings in `docs/dependencies/*` updated to match (no dependency
       changed, so the regenerated content differs only in those strings).
-- [ ] Build the affected modules and run the tests — **blocked locally**:
-      the remote session's network policy returns 403 for the Spine
-      artifact repositories, so Gradle cannot resolve the SDK snapshot
-      dependencies. Verification delegated to PR CI.
+- [x] Build the affected modules and run the tests — done locally on a
+      machine with artifact-repository access: `:base:test` runs
+      `MessageFileSpec` green (3/3), and `:plugins`/`:signal-tests` test
+      sources compile against the moved type. (Original remote session
+      hit 403 from the Spine repos; that block is now resolved.)
 - [x] Commit, push, draft PR referencing base-libraries#941.
 
 ## Log
@@ -58,3 +59,6 @@ all in-repo consumers switched to the new type and the ported unit test green.
 - 2026-06-10 — drafted; executing (work authorized by the issue assignment).
 - 2026-06-10 — sources done; local Gradle build impossible (403 from all
   Spine repos under the session network policy); relying on PR CI.
+- 2026-06-10 — verified locally (JDK 17): `:base:test --tests MessageFileSpec`
+  passes 3/3; `:plugins` and `:signal-tests` test sources compile. CI green on
+  Ubuntu; only the Windows build remained pending.

--- a/base/src/main/kotlin/io/spine/tools/core/jvm/MessageFile.kt
+++ b/base/src/main/kotlin/io/spine/tools/core/jvm/MessageFile.kt
@@ -36,22 +36,22 @@ import java.util.function.Predicate
 public enum class MessageFile(fileName: String) : Predicate<FileDescriptorProto> {
 
     /**
-     * Commands are declared in a file which name ends with `"commands.proto"`.
+     * Commands are declared in a file whose name ends with `"commands.proto"`.
      */
     COMMANDS("commands"),
 
     /**
-     * Events are declared in a file which name ends with `"events.proto"`.
+     * Events are declared in a file whose name ends with `"events.proto"`.
      */
     EVENTS("events"),
 
     /**
-     * Rejections are declared in a file which name ends with `"rejections.proto"`.
+     * Rejections are declared in a file whose name ends with `"rejections.proto"`.
      */
     REJECTIONS("rejections");
 
     /**
-     * The suffix required for this kind of files.
+     * The suffix required for this kind of file.
      */
     public val suffix: String = fileName + FileName.EXTENSION
 

--- a/base/src/main/kotlin/io/spine/tools/core/jvm/MessageFile.kt
+++ b/base/src/main/kotlin/io/spine/tools/core/jvm/MessageFile.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm
+
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto
+import io.spine.code.proto.FileName
+import java.util.function.Predicate
+
+/**
+ * An enumeration of file naming conventions for pre-defined types of messages.
+ */
+public enum class MessageFile(fileName: String) : Predicate<FileDescriptorProto> {
+
+    /**
+     * Commands are declared in a file which name ends with `"commands.proto"`.
+     */
+    COMMANDS("commands"),
+
+    /**
+     * Events are declared in a file which name ends with `"events.proto"`.
+     */
+    EVENTS("events"),
+
+    /**
+     * Rejections are declared in a file which name ends with `"rejections.proto"`.
+     */
+    REJECTIONS("rejections");
+
+    /**
+     * The suffix required for this kind of files.
+     */
+    public val suffix: String = fileName + FileName.EXTENSION
+
+    /**
+     * Checks if the name of the given file matches this suffix.
+     */
+    override fun test(file: FileDescriptorProto): Boolean = file.name.endsWith(suffix)
+}

--- a/base/src/main/kotlin/io/spine/tools/core/jvm/gradle/settings/CoreJvmCompilerSettings.kt
+++ b/base/src/main/kotlin/io/spine/tools/core/jvm/gradle/settings/CoreJvmCompilerSettings.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,9 +30,9 @@ package io.spine.tools.core.jvm.gradle.settings
 
 import com.google.common.collect.ImmutableList
 import io.spine.annotation.Internal
-import io.spine.base.MessageFile
 import io.spine.tools.compiler.ast.FilePattern
 import io.spine.tools.compiler.ast.FilePatternFactory
+import io.spine.tools.core.jvm.MessageFile
 import io.spine.tools.core.jvm.gradle.settings.SignalSettings.Companion.DEFAULT_COMMAND_ACTIONS
 import io.spine.tools.core.jvm.gradle.settings.SignalSettings.Companion.DEFAULT_EVENT_ACTIONS
 import io.spine.tools.core.jvm.gradle.settings.SignalSettings.Companion.DEFAULT_REJECTION_ACTIONS
@@ -61,7 +61,7 @@ public class CoreJvmCompilerSettings @Internal public constructor(private val pr
      */
     public val commands: SignalSettings = SignalSettings(
         project,
-        MessageFile.COMMANDS.suffix(),
+        MessageFile.COMMANDS.suffix,
         DEFAULT_COMMAND_ACTIONS
     )
 
@@ -70,7 +70,7 @@ public class CoreJvmCompilerSettings @Internal public constructor(private val pr
      */
     public val events: SignalSettings = SignalSettings(
         project,
-        MessageFile.EVENTS.suffix(),
+        MessageFile.EVENTS.suffix,
         DEFAULT_EVENT_ACTIONS
     )
 
@@ -79,7 +79,7 @@ public class CoreJvmCompilerSettings @Internal public constructor(private val pr
      */
     public val rejections: SignalSettings = SignalSettings(
         project,
-        MessageFile.REJECTIONS.suffix(),
+        MessageFile.REJECTIONS.suffix,
         DEFAULT_REJECTION_ACTIONS
     )
 

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/MessageFileSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/MessageFileSpec.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm
+
+import com.google.protobuf.Any
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("`MessageFile` should")
+internal class MessageFileSpec {
+
+    @Test
+    fun `expose the suffix required for the corresponding kind of files`() {
+        MessageFile.COMMANDS.suffix shouldBe "commands.proto"
+        MessageFile.EVENTS.suffix shouldBe "events.proto"
+        MessageFile.REJECTIONS.suffix shouldBe "rejections.proto"
+    }
+
+    @Nested internal inner class
+    `test a file descriptor` {
+
+        @Test
+        fun `accepting the file with matching suffix`() {
+            val file = FileDescriptorProto.newBuilder()
+                .setName("given_events.proto")
+                .build()
+            MessageFile.EVENTS.test(file) shouldBe true
+        }
+
+        @Test
+        fun `rejecting the file with non-matching suffix`() {
+            val file = Any.getDescriptor().file.toProto()
+            MessageFile.EVENTS.test(file) shouldBe false
+        }
+    }
+}

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:core-jvm-annotation:2.0.0-SNAPSHOT.068`
+# Dependencies of `io.spine.tools:core-jvm-annotation:2.0.0-SNAPSHOT.069`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -1177,7 +1177,7 @@ This report was generated on **Mon Jun 01 18:09:54 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-base:2.0.0-SNAPSHOT.068`
+# Dependencies of `io.spine.tools:core-jvm-base:2.0.0-SNAPSHOT.069`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -2362,7 +2362,7 @@ This report was generated on **Mon Jun 01 18:09:54 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-comparable:2.0.0-SNAPSHOT.068`
+# Dependencies of `io.spine.tools:core-jvm-comparable:2.0.0-SNAPSHOT.069`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -3539,7 +3539,7 @@ This report was generated on **Mon Jun 01 18:09:54 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-comparable-tests:2.0.0-SNAPSHOT.068`
+# Dependencies of `io.spine.tools:core-jvm-comparable-tests:2.0.0-SNAPSHOT.069`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4527,7 +4527,7 @@ This report was generated on **Mon Jun 01 18:09:54 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-entity:2.0.0-SNAPSHOT.068`
+# Dependencies of `io.spine.tools:core-jvm-entity:2.0.0-SNAPSHOT.069`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -5704,7 +5704,7 @@ This report was generated on **Mon Jun 01 18:09:54 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-entity-tests:2.0.0-SNAPSHOT.068`
+# Dependencies of `io.spine.tools:core-jvm-entity-tests:2.0.0-SNAPSHOT.069`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6692,7 +6692,7 @@ This report was generated on **Mon Jun 01 18:09:54 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-grpc:2.0.0-SNAPSHOT.068`
+# Dependencies of `io.spine.tools:core-jvm-grpc:2.0.0-SNAPSHOT.069`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -7840,7 +7840,7 @@ This report was generated on **Mon Jun 01 18:09:54 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-ksp:2.0.0-SNAPSHOT.068`
+# Dependencies of `io.spine.tools:core-jvm-ksp:2.0.0-SNAPSHOT.069`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -9080,7 +9080,7 @@ This report was generated on **Mon Jun 01 18:09:54 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-marker:2.0.0-SNAPSHOT.068`
+# Dependencies of `io.spine.tools:core-jvm-marker:2.0.0-SNAPSHOT.069`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -10265,7 +10265,7 @@ This report was generated on **Mon Jun 01 18:09:54 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-marker-tests:2.0.0-SNAPSHOT.068`
+# Dependencies of `io.spine.tools:core-jvm-marker-tests:2.0.0-SNAPSHOT.069`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -11253,7 +11253,7 @@ This report was generated on **Mon Jun 01 18:09:54 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-message-group:2.0.0-SNAPSHOT.068`
+# Dependencies of `io.spine.tools:core-jvm-message-group:2.0.0-SNAPSHOT.069`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -12438,7 +12438,7 @@ This report was generated on **Mon Jun 01 18:09:54 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-message-group-tests:2.0.0-SNAPSHOT.068`
+# Dependencies of `io.spine.tools:core-jvm-message-group-tests:2.0.0-SNAPSHOT.069`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -13426,7 +13426,7 @@ This report was generated on **Mon Jun 01 18:09:54 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-plugins:2.0.0-SNAPSHOT.068`
+# Dependencies of `io.spine.tools:core-jvm-plugins:2.0.0-SNAPSHOT.069`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -14682,7 +14682,7 @@ This report was generated on **Mon Jun 01 18:09:54 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-routing:2.0.0-SNAPSHOT.068`
+# Dependencies of `io.spine.tools:core-jvm-routing:2.0.0-SNAPSHOT.069`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -15959,7 +15959,7 @@ This report was generated on **Mon Jun 01 18:09:54 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-routing-tests:2.0.0-SNAPSHOT.068`
+# Dependencies of `io.spine.tools:core-jvm-routing-tests:2.0.0-SNAPSHOT.069`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -16699,7 +16699,7 @@ This report was generated on **Mon Jun 01 18:09:54 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-signal:2.0.0-SNAPSHOT.068`
+# Dependencies of `io.spine.tools:core-jvm-signal:2.0.0-SNAPSHOT.069`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -17884,7 +17884,7 @@ This report was generated on **Mon Jun 01 18:09:54 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-signal-tests:2.0.0-SNAPSHOT.068`
+# Dependencies of `io.spine.tools:core-jvm-signal-tests:2.0.0-SNAPSHOT.069`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -18872,7 +18872,7 @@ This report was generated on **Mon Jun 01 18:09:54 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-uuid:2.0.0-SNAPSHOT.068`
+# Dependencies of `io.spine.tools:core-jvm-uuid:2.0.0-SNAPSHOT.069`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -20057,7 +20057,7 @@ This report was generated on **Mon Jun 01 18:09:54 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-uuid-tests:2.0.0-SNAPSHOT.068`
+# Dependencies of `io.spine.tools:core-jvm-uuid-tests:2.0.0-SNAPSHOT.069`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>core-jvm-compiler</artifactId>
-<version>2.0.0-SNAPSHOT.068</version>
+<version>2.0.0-SNAPSHOT.069</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/plugins/src/test/kotlin/io/spine/tools/core/jvm/gradle/plugins/CoreJvmOptionsSpec.kt
+++ b/plugins/src/test/kotlin/io/spine/tools/core/jvm/gradle/plugins/CoreJvmOptionsSpec.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,12 +31,12 @@ import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import io.spine.base.MessageFile
 import io.spine.option.OptionsProto
 import io.spine.testing.SlowTest
 import io.spine.tools.compiler.jvm.render.ImplementInterface
 import io.spine.tools.compiler.render.actions
 import io.spine.tools.compiler.render.add
+import io.spine.tools.core.jvm.MessageFile
 import io.spine.tools.core.jvm.NoOpMessageAction
 import io.spine.tools.core.jvm.applyStandard
 import io.spine.tools.core.jvm.field.AddFieldClass
@@ -311,7 +311,7 @@ class CoreJvmOptionsSpec {
         fun commands() {
             signalSettings.commands.run {
                 patternList shouldHaveSize 1
-                patternList[0].suffix shouldBe MessageFile.COMMANDS.suffix()
+                patternList[0].suffix shouldBe MessageFile.COMMANDS.suffix
             }
         }
 
@@ -319,7 +319,7 @@ class CoreJvmOptionsSpec {
         fun events() {
             signalSettings.events.run {
                 patternList shouldHaveSize 1
-                patternList[0].suffix shouldBe MessageFile.EVENTS.suffix()
+                patternList[0].suffix shouldBe MessageFile.EVENTS.suffix
             }
         }
 
@@ -327,7 +327,7 @@ class CoreJvmOptionsSpec {
         fun rejections() {
             signalSettings.rejections.run {
                 patternList shouldHaveSize 1
-                patternList[0].suffix shouldBe MessageFile.REJECTIONS.suffix()
+                patternList[0].suffix shouldBe MessageFile.REJECTIONS.suffix
             }
         }
 

--- a/signal-tests/src/test/kotlin/io/spine/tools/core/jvm/signal/SignalDiscoverySpec.kt
+++ b/signal-tests/src/test/kotlin/io/spine/tools/core/jvm/signal/SignalDiscoverySpec.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,10 +29,6 @@ package io.spine.tools.core.jvm.signal
 import com.google.protobuf.Descriptors.FileDescriptor
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.spine.base.EntityState
-import io.spine.base.MessageFile
-import io.spine.base.MessageFile.COMMANDS
-import io.spine.base.MessageFile.EVENTS
-import io.spine.base.MessageFile.REJECTIONS
 import io.spine.code.proto.FileSet
 import io.spine.tools.compiler.ast.File
 import io.spine.tools.compiler.ast.matches
@@ -40,6 +36,10 @@ import io.spine.tools.compiler.backend.Pipeline
 import io.spine.tools.compiler.protobuf.file
 import io.spine.tools.compiler.protobuf.toMessageType
 import io.spine.tools.compiler.render.TypeListActions
+import io.spine.tools.core.jvm.MessageFile
+import io.spine.tools.core.jvm.MessageFile.COMMANDS
+import io.spine.tools.core.jvm.MessageFile.EVENTS
+import io.spine.tools.core.jvm.MessageFile.REJECTIONS
 import io.spine.testing.compiler.PipelineSetup
 import io.spine.testing.server.blackbox.BlackBox
 import java.nio.file.Path

--- a/signal-tests/src/test/kotlin/io/spine/tools/core/jvm/signal/SignalPluginTestSetup.kt
+++ b/signal-tests/src/test/kotlin/io/spine/tools/core/jvm/signal/SignalPluginTestSetup.kt
@@ -62,4 +62,4 @@ internal abstract class SignalPluginTestSetup : PluginTestSetup<SignalSettings>(
 /**
  * Creates [FilePattern] corresponding to this [MessageFile] type.
  */
-internal fun MessageFile.pattern(): FilePattern = suffix(suffix)
+internal fun MessageFile.pattern(): FilePattern = suffix(this.suffix)

--- a/signal-tests/src/test/kotlin/io/spine/tools/core/jvm/signal/SignalPluginTestSetup.kt
+++ b/signal-tests/src/test/kotlin/io/spine/tools/core/jvm/signal/SignalPluginTestSetup.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +26,9 @@
 
 package io.spine.tools.core.jvm.signal
 
-import io.spine.base.MessageFile
 import io.spine.tools.compiler.ast.FilePattern
 import io.spine.tools.compiler.ast.FilePatternFactory.suffix
+import io.spine.tools.core.jvm.MessageFile
 import io.spine.tools.core.jvm.PluginTestSetup
 import io.spine.tools.core.jvm.settings.SignalSettings
 import java.nio.file.Path
@@ -62,4 +62,4 @@ internal abstract class SignalPluginTestSetup : PluginTestSetup<SignalSettings>(
 /**
  * Creates [FilePattern] corresponding to this [MessageFile] type.
  */
-internal fun MessageFile.pattern(): FilePattern = suffix(suffix())
+internal fun MessageFile.pattern(): FilePattern = suffix(suffix)

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,5 +29,5 @@
  *
  * Do not rename this property, as it is also used in the integration tests via its name.
  */
-val coreJvmCompilerVersion by extra("2.0.0-SNAPSHOT.068")
+val coreJvmCompilerVersion by extra("2.0.0-SNAPSHOT.069")
 val versionToPublish by extra(coreJvmCompilerVersion)


### PR DESCRIPTION
Part of SpineEventEngine/base-libraries#941.

The `MessageFile` enum encodes the code-generation file-naming convention (`commands.proto`, `events.proto`, `rejections.proto`). Its only production consumer across the organisation is `CoreJvmCompilerSettings` in this repository, so the enum moves here from `io.spine.base`.

## Changes

- New `io.spine.tools.core.jvm.MessageFile` in the `base` module — a Kotlin conversion of the Java original; `suffix()` becomes the `suffix` property, the `Predicate<FileDescriptorProto>` contract is retained.
- `CoreJvmCompilerSettings`, `CoreJvmOptionsSpec`, `SignalPluginTestSetup`, and `SignalDiscoverySpec` switch to the new type.
- The unit test is ported as `MessageFileSpec` (Kotest), using a synthetic `FileDescriptorProto` instead of the test-only proto file the Java original needed, plus a test pinning the conventional suffix values.
- Version bumped to `2.0.0-SNAPSHOT.069`; dependency report version strings aligned (no dependency changed).

## Coordination

This PR is self-contained: the pinned `spine-base` still ships `io.spine.base.MessageFile`, but nothing here references it anymore, so it can merge before or after the companion removal PR in `base-libraries`. A future `Base` bump past the removal requires no further work here.

Companion PR: SpineEventEngine/base-libraries (removal of the original enum), linked from #941.

https://claude.ai/code/session_01RoCv4qxE8c32kPMLWVKw9M

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoCv4qxE8c32kPMLWVKw9M)_