### PR TITLE
Raise test coverage in `annotation` and `base`, fixing four defects en route

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -10,6 +10,7 @@ See [README.md](README.md) for the format and routing rules.
 ## Project (durable context & rationale)
 
 - [windows-ci-needs-real-symlinks](project/windows-ci-needs-real-symlinks.md) — `tests/` build needs git symlinks checked out natively; never set `core.symlinks false` in Windows CI.
+- [prototap-build-cache](project/prototap-build-cache.md) — Build-cache hits on `*-tests` protoc tasks drop the ProtoTap capture; rerun with `--no-build-cache` when `prototap/CodeGeneratorRequest.binpb` is missing.
 
 ## Reference (external systems)
 

--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -11,6 +11,7 @@ See [README.md](README.md) for the format and routing rules.
 
 - [windows-ci-needs-real-symlinks](project/windows-ci-needs-real-symlinks.md) — `tests/` build needs git symlinks checked out natively; never set `core.symlinks false` in Windows CI.
 - [prototap-build-cache](project/prototap-build-cache.md) — Build-cache hits on `*-tests` protoc tasks drop the ProtoTap capture; rerun with `--no-build-cache` when `prototap/CodeGeneratorRequest.binpb` is missing.
+- [igtest-stale-plugins](project/igtest-stale-plugins.md) — IgTests can silently run previously published plugins; clear stale artifact meta (`writeArtifactMeta --rerun`), build cache, and warm daemons before trusting results.
 
 ## Reference (external systems)
 

--- a/.agents/memory/project/igtest-stale-plugins.md
+++ b/.agents/memory/project/igtest-stale-plugins.md
@@ -1,0 +1,35 @@
+---
+name: igtest-stale-plugins
+description: ApiAnnotationsPluginIgTest can silently run previously published plugins — three staleness layers (artifact meta, build cache, warm daemons) must be cleared to test current code.
+metadata:
+  type: project
+  since: 2026-06-11
+---
+
+The IgTest's nested TestKit build does not necessarily run the plugin code
+from the working tree. The CoreJvm Compiler Gradle plugin resolves its
+companion `core-jvm-plugins` fat jar at the version recorded in the jar's
+own `META-INF/io.spine/io.spine.tools_core-jvm-plugins.meta` resource, and
+three independent layers can pin that to a previously published version:
+
+1. `writeArtifactMeta` (tool-base plugin) declares no task inputs, so it
+   stays `UP-TO-DATE` across version bumps and keeps the old version in
+   the meta resource. Remedy: `./gradlew :plugins:writeArtifactMeta --rerun`.
+2. The Gradle build cache can restore `launchSpineCompiler` output that was
+   generated with older plugins. Remedy: `--no-build-cache`.
+3. Warm daemons memoize the lazily loaded meta (`LazyMeta` is a singleton
+   `by lazy`), so even a corrected jar keeps resolving the old version
+   until the daemon dies. Remedy: `./gradlew --stop` and delete
+   `.gradle-test-kit/test-kit-daemon` (TestKit daemons are shared across
+   IgTest runs via `withSharedTestKitDirectory()`).
+
+**Why:** on 2026-06-11 a behavioral fix passed the in-JVM
+`annotation-tests` suite but failed the IgTest: the nested build ran fat
+jar `.070` while the tree was at `.072`. Diagnose by reading
+`typedefs/build/spine/compiler/parameters/main.pb.json` in the nested
+project — `userClasspath` names the fat jar actually used.
+
+**How to apply:** when an IgTest contradicts the in-JVM suites, check the
+`userClasspath` version first; clear the three layers above before
+trusting the result. Root fix tracked for tool-base (`WriteArtifactMeta`
+inputs). Related: [[prototap-build-cache]].

--- a/.agents/memory/project/prototap-build-cache.md
+++ b/.agents/memory/project/prototap-build-cache.md
@@ -1,0 +1,24 @@
+---
+name: prototap-build-cache
+description: Build-cache hits on protoc tasks of `*-tests` modules drop the ProtoTap capture; rerun with `--no-build-cache` when `prototap/CodeGeneratorRequest.binpb` is missing.
+metadata:
+  type: project
+  since: 2026-06-11
+---
+
+In `*-tests` modules (e.g. `annotation-tests`), `PluginTestSetup` loads
+`prototap/CodeGeneratorRequest.binpb` from test resources. ProtoTap writes
+that capture as a side effect of the protoc run without declaring it as a
+task output, so a Gradle build-cache hit on the proto generation task
+restores the generated Java but not the capture. Every spec in the module
+then fails in `@BeforeAll` with
+``Unable to find `prototap/CodeGeneratorRequest.binpb` ``.
+
+**Why:** observed on 2026-06-11: `:annotation-tests:clean
+:annotation-tests:build` failed all specs after a cache hit; the identical
+build with `--no-build-cache` passed.
+
+**How to apply:** after `clean` of a `*-tests` module — or whenever the
+`.binpb` resource error appears — rerun the build with `--no-build-cache`.
+The root fix belongs in the ProtoTap plugin: declare the capture files as
+task outputs.

--- a/.agents/memory/project/prototap-build-cache.md
+++ b/.agents/memory/project/prototap-build-cache.md
@@ -22,5 +22,11 @@ build with `--no-build-cache` passed.
 for `GenerateProtoTask`s in modules applying ProtoTap (see the
 `subprojects` block), so the capture is always produced. If the error
 still appears, check that the module applies the `prototap` plugin and
-that the guard is in place. The proper fix belongs in the ProtoTap
-plugin: declare the capture files as task outputs.
+that the guard is in place.
+
+**Root fix:** implemented in ProtoTap 0.15.0 (branch
+`support-gradle-build-cache`, 2026-06-11): the Gradle plugin declares the
+tapped files (`CodeGeneratorRequest.binpb`, `CodeGeneratorRequest.pb.json`,
+`CompiledProtoFiles.txt`) as `GenerateProtoTask` outputs, so build-cache
+hits restore them. Once this repo depends on ProtoTap ≥ 0.15.0, remove
+the root-build guard and delete this memory.

--- a/.agents/memory/project/prototap-build-cache.md
+++ b/.agents/memory/project/prototap-build-cache.md
@@ -18,7 +18,9 @@ then fails in `@BeforeAll` with
 :annotation-tests:build` failed all specs after a cache hit; the identical
 build with `--no-build-cache` passed.
 
-**How to apply:** after `clean` of a `*-tests` module — or whenever the
-`.binpb` resource error appears — rerun the build with `--no-build-cache`.
-The root fix belongs in the ProtoTap plugin: declare the capture files as
-task outputs.
+**How to apply:** the root `build.gradle.kts` now disables build caching
+for `GenerateProtoTask`s in modules applying ProtoTap (see the
+`subprojects` block), so the capture is always produced. If the error
+still appears, check that the module applies the `prototap` plugin and
+that the guard is in place. The proper fix belongs in the ProtoTap
+plugin: declare the capture files as task outputs.

--- a/.agents/tasks/file-option-enum-events.md
+++ b/.agents/tasks/file-option-enum-events.md
@@ -1,0 +1,61 @@
+---
+slug: file-option-enum-events
+branch: raise-coverage
+owner: claude
+status: done
+started: 2026-06-11
+---
+
+## Goal
+
+File-wide API options (e.g. `(internal_all) = true`) propagate to enums
+declared in the file, so generated Java enums get the corresponding
+API-level annotations, as messages and services already do.
+
+## Context
+
+`FileOptionsProcess` emits `FileOptionMatched` events only for entries of
+`typeMap` (messages) and `serviceMap`. Enums (`enumTypeMap`) are skipped,
+although the event declares an `enum_type` target, `toEnumTypeName()`
+exists, and `EnumAnnotationsView` subscribes to the event. As a result
+`EnumAnnotator.annotateType` is dead code for file-wide options.
+
+The gap was verified empirically by the in-JVM `PipelineSetup` test in
+the `annotation-tests` module: the test
+`not yet annotate an enum declared in a file with a file-wide option`
+documents the broken behavior.
+
+## Plan
+
+- [x] Confirm `ProtobufSourceFile.enum_type` map and `EnumType.name`
+      in the compiler API (`compiler/api`, `source.proto`, `ast.proto`).
+- [x] Add `addEnumEvents` to `FileOptionsProcess.kt`, mirroring
+      `addMessageEvents`, with `apiOption.messageOption` as `assumed`.
+- [x] Set `file = e.file` in `EnumAnnotationsView` handlers (see Log).
+- [x] Flip `EnumAnnotatorSpec`: the `Level` enum from
+      `internal_all_multiple.proto` must now be annotated `@Internal`.
+- [x] Run `:annotation:test` and `:annotation-tests:test`.
+- [x] Commit the fix (`4a4559b12`, three files only).
+- [x] Full `./gradlew build` for downstream modules (`plugins`
+      consumes `:annotation`). The only failure is unrelated to this
+      task (see Log).
+
+## Log
+
+- 2026-06-11 — verified event wiring (`EnumAnnotationsView`, routing) and
+  the compiler AST shape; only `EnumAnnotatorSpec` asserts the old behavior.
+- 2026-06-11 — `addEnumEvents` alone was not enough: the flipped test still
+  failed. Root cause: `EnumAnnotations.file` is `(required) = true`, but
+  `EnumAnnotationsView` handlers never set `file`, so the view state failed
+  validation and was never stored; `ProtoAnnotator.doRender()` then selected
+  nothing. Mirrored `MessageAnnotationsView`: set `file = e.file` in both
+  handlers, plus the same option-dedup guards. All 23 + 48 tests pass.
+- 2026-06-11 — committed as `4a4559b12` (three files only, per request).
+- 2026-06-11 — full `./gradlew build --continue`: single failure,
+  `ApiAnnotationsPluginIgTest > not annotate > if message option overrides
+  file option`. Not caused by this task: a concurrent session edited that
+  test (working tree, 18:35) to check top-level classes instead of nested
+  ones, exposing the pre-existing "false option does not revert file-wide
+  option" gap tracked by `honor-false-api-options.md`. The fixture type is
+  a message; this task changed only enum propagation. Everything else,
+  including `:annotation-tests:test` and all downstream modules, passed.

--- a/.agents/tasks/honor-false-api-options.md
+++ b/.agents/tasks/honor-false-api-options.md
@@ -1,0 +1,63 @@
+---
+slug: honor-false-api-options
+branch: raise-coverage
+owner: claude
+status: in-progress
+started: 2026-06-11
+---
+
+## Goal
+
+A message-level `option (internal_type) = false;` reverts a file-wide
+`option (internal_all) = true;`, so the generated class is *not* annotated
+`@Internal`. More generally: annotators honor the *value* of API-level
+options everywhere, instead of treating mere option presence as `true`.
+
+## Context
+
+Verified with an in-JVM `PipelineSetup` test: `Reverting` from
+`reverting.proto` *is* annotated despite `(internal_type) = false`.
+Root cause: `MessageAnnotationsView` correctly keeps the message-level
+`false` option, but `TypeAnnotator.annotate` maps view options through
+`ApiOption.findMatching`, which matches by name only. The same
+name-only pattern exists in `FieldAnnotator.annotateField` and
+`OuterClassAnnotationDiscovery.on(FileEntered)`. Additionally,
+`MessageOrEnumAnnotator.needsAnnotation` compares full `Option` messages
+(`header.optionList.contains(...)`), which never matches compiler-produced
+options (they carry the field number), so the single-file semantic
+duplication check is dead code.
+
+The IgTest case "not annotate / if message option overrides file option"
+is vacuous: for a `java_multiple_files = true` proto it inspects nested
+types of the (empty) outer class.
+
+## Plan
+
+- [x] `TypeAnnotator.annotate`: skip options whose value is not `true`
+      (`Option.value.isTrue()` from `ApiOption.kt`).
+- [x] `FieldAnnotator.annotateField`: same value filter for field options.
+- [x] `OuterClassAnnotationDiscovery`: same value filter for file options.
+- [x] `MessageOrEnumAnnotator.needsAnnotation`: match the header option by
+      name and `true` value instead of whole-message equality.
+- [x] Fixtures (`annotation-tests`): add a `false`-valued field option to
+      `reverting.proto`; add single-file `outer_reverting.proto` with
+      `(internal_all) = false`.
+- [x] Specs: flip and rename the documenting test in `MessageAnnotatorSpec`
+      (`shouldNotContain`); add nested-type suppression test (single-file +
+      file-wide option ⇒ only the outer class is annotated); add
+      `FieldAnnotatorSpec` and `OuterClassAnnotatorSpec` cases for
+      `false`-valued options.
+- [x] IgTest: make "if message option overrides file option" non-vacuous
+      via `checkTypeAnnotations` (the proto is `java_multiple_files = true`).
+- [ ] Run `:annotation:test` and `:annotation-tests:test`; fix fallout.
+  - `:annotation-tests:build` green (26/26) with `--no-build-cache`;
+    see the `prototap-build-cache` memory for the cache gotcha.
+  - `:annotation:test` (incl. the IgTest) running.
+
+## Log
+
+- 2026-06-11 — investigation handed over from the previous session;
+  plan drafted; executing.
+- 2026-06-11 — code changes done; `:annotation-tests` suite green
+  (the user flipped the `Reverting` test concurrently in the IDE;
+  kept their wording, added the `OrBuilder` assertion).

--- a/.agents/tasks/honor-false-api-options.md
+++ b/.agents/tasks/honor-false-api-options.md
@@ -2,7 +2,7 @@
 slug: honor-false-api-options
 branch: raise-coverage
 owner: claude
-status: in-progress
+status: in-review
 started: 2026-06-11
 ---
 
@@ -49,10 +49,12 @@ types of the (empty) outer class.
       `false`-valued options.
 - [x] IgTest: make "if message option overrides file option" non-vacuous
       via `checkTypeAnnotations` (the proto is `java_multiple_files = true`).
-- [ ] Run `:annotation:test` and `:annotation-tests:test`; fix fallout.
+- [x] Run `:annotation:test` and `:annotation-tests:test`; fix fallout.
   - `:annotation-tests:build` green (26/26) with `--no-build-cache`;
     see the `prototap-build-cache` memory for the cache gotcha.
-  - `:annotation:test` (incl. the IgTest) running.
+  - `:annotation:test` green (48/48) after clearing the staleness layers
+    described in the `igtest-stale-plugins` memory; the non-vacuous
+    IgTest check now passes against the `.072` fat jar.
 
 ## Log
 
@@ -61,3 +63,11 @@ types of the (empty) outer class.
 - 2026-06-11 — code changes done; `:annotation-tests` suite green
   (the user flipped the `Reverting` test concurrently in the IDE;
   kept their wording, added the `OrBuilder` assertion).
+- 2026-06-11 — first `:annotation:test` run failed only on the
+  newly non-vacuous IgTest check: the nested build ran fat jar `.070`
+  (stale `writeArtifactMeta` resource + build cache + warm daemons; see
+  the `igtest-stale-plugins` memory). After `writeArtifactMeta --rerun`,
+  republishing, `--stop`, and clearing the TestKit daemon/cache, the
+  manual repro generates `ReveringFileOption` without `@Internal`,
+  keeps `InternalMessage` nested types annotated, and annotates only
+  the outer class in `OuterInternal` (1 annotation vs 7 before).

--- a/annotation-tests/build.gradle.kts
+++ b/annotation-tests/build.gradle.kts
@@ -24,35 +24,27 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+import io.spine.dependency.lib.Protobuf
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+plugins {
+    module
+    protobuf
+    prototap
+    `test-module`
+}
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
+dependencies {
+    arrayOf(
+        project(":base"),
+        project(":annotation"),
+        testFixtures(project(":base"))
+    ).forEach {
+        testImplementation(it)
     }
+}
+
+forceSpineBase()
+
+protobuf {
+    protoc { artifact = Protobuf.compiler }
 }

--- a/annotation-tests/src/test/kotlin/io/spine/tools/core/jvm/annotation/AnnotationPluginTestSetup.kt
+++ b/annotation-tests/src/test/kotlin/io/spine/tools/core/jvm/annotation/AnnotationPluginTestSetup.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.annotation
+
+import io.spine.annotation.Beta
+import io.spine.annotation.Experimental
+import io.spine.annotation.Internal
+import io.spine.annotation.SPI
+import io.spine.tools.core.annotation.ApiAnnotationsPlugin
+import io.spine.tools.core.jvm.PluginTestSetup
+import java.nio.file.Path
+import kotlin.io.path.Path
+
+/**
+ * Abstract base for [ApiAnnotationsPlugin] tests.
+ *
+ * The setup mimics the settings written for the plugin by
+ * the CoreJvm Compiler Gradle plugin: standard Spine annotation types and,
+ * optionally, patterns for annotating classes and methods as `internal`.
+ */
+internal abstract class AnnotationPluginTestSetup(
+    private val internalClassPatterns: List<String> = listOf(),
+    private val internalMethodNames: List<String> = listOf()
+) : PluginTestSetup<Settings>(ApiAnnotationsPlugin(), ApiAnnotationsPlugin.SETTINGS_ID) {
+
+    /**
+     * The directory with the Java code generated for the fixture proto files.
+     */
+    val generatedPackage: Path = Path("given/annotation")
+
+    override fun createSettings(projectDir: Path): Settings = settings {
+        annotationTypes = SettingsKt.annotationTypes {
+            experimental = Experimental::class.java.canonicalName
+            beta = Beta::class.java.canonicalName
+            spi = SPI::class.java.canonicalName
+            internal = Internal::class.java.canonicalName
+        }
+        internalClassPattern.addAll(this@AnnotationPluginTestSetup.internalClassPatterns)
+        internalMethodName.addAll(this@AnnotationPluginTestSetup.internalMethodNames)
+    }
+
+    fun generateCode(projectDir: Path) {
+        runPipeline(projectDir)
+    }
+
+    /**
+     * Obtains the code of the Java file generated for the type with the given simple name.
+     */
+    fun code(simpleName: String): String =
+        file(generatedPackage.resolve("$simpleName.java")).code()
+}
+
+/**
+ * The annotation lines added to the generated code.
+ */
+internal const val INTERNAL = "@io.spine.annotation.Internal"
+internal const val BETA = "@io.spine.annotation.Beta"
+internal const val EXPERIMENTAL = "@io.spine.annotation.Experimental"
+internal const val SPI_ANNOTATION = "@io.spine.annotation.SPI"

--- a/annotation-tests/src/test/kotlin/io/spine/tools/core/jvm/annotation/AnnotationPluginTestSetup.kt
+++ b/annotation-tests/src/test/kotlin/io/spine/tools/core/jvm/annotation/AnnotationPluginTestSetup.kt
@@ -75,9 +75,21 @@ internal abstract class AnnotationPluginTestSetup(
 }
 
 /**
- * The annotation lines added to the generated code.
+ * The `@Internal` annotation line added to the generated code.
  */
 internal const val INTERNAL = "@io.spine.annotation.Internal"
+
+/**
+ * The `@Beta` annotation line added to the generated code.
+ */
 internal const val BETA = "@io.spine.annotation.Beta"
+
+/**
+ * The `@Experimental` annotation line added to the generated code.
+ */
 internal const val EXPERIMENTAL = "@io.spine.annotation.Experimental"
+
+/**
+ * The `@SPI` annotation line added to the generated code.
+ */
 internal const val SPI_ANNOTATION = "@io.spine.annotation.SPI"

--- a/annotation-tests/src/test/kotlin/io/spine/tools/core/jvm/annotation/ClassPatternAnnotatorSpec.kt
+++ b/annotation-tests/src/test/kotlin/io/spine/tools/core/jvm/annotation/ClassPatternAnnotatorSpec.kt
@@ -24,35 +24,39 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+package io.spine.tools.core.jvm.annotation
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import java.nio.file.Path
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
+@DisplayName("`ClassPatternAnnotator` should")
+internal class ClassPatternAnnotatorSpec {
+
+    companion object : AnnotationPluginTestSetup(
+        internalClassPatterns = listOf(".*PlainOne")
+    ) {
+
+        @BeforeAll
+        @JvmStatic
+        fun setup(@TempDir projectDir: Path) {
+            generateCode(projectDir)
+        }
+    }
+
+    @Test
+    fun `annotate classes matching a pattern as 'internal'`() {
+        val code = code("PlainOne")
+        code.substringBefore("class PlainOne") shouldContain INTERNAL
+    }
+
+    @Test
+    fun `not annotate classes which do not match`() {
+        code("PlainOneOrBuilder") shouldNotContain INTERNAL
+        code("PlainLevel") shouldNotContain INTERNAL
     }
 }

--- a/annotation-tests/src/test/kotlin/io/spine/tools/core/jvm/annotation/EnumAnnotatorSpec.kt
+++ b/annotation-tests/src/test/kotlin/io/spine/tools/core/jvm/annotation/EnumAnnotatorSpec.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.annotation
+
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import java.nio.file.Path
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+@DisplayName("`EnumAnnotator` should")
+internal class EnumAnnotatorSpec {
+
+    companion object : AnnotationPluginTestSetup() {
+
+        @BeforeAll
+        @JvmStatic
+        fun setup(@TempDir projectDir: Path) {
+            generateCode(projectDir)
+        }
+    }
+
+    @Test
+    fun `annotate an enum declared in a file with a file-wide option`() {
+        code("Level") shouldContain INTERNAL
+    }
+
+    @Test
+    fun `not annotate an enum without API level options`() {
+        code("PlainLevel") shouldNotContain INTERNAL
+    }
+}

--- a/annotation-tests/src/test/kotlin/io/spine/tools/core/jvm/annotation/FieldAnnotatorSpec.kt
+++ b/annotation-tests/src/test/kotlin/io/spine/tools/core/jvm/annotation/FieldAnnotatorSpec.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.annotation
+
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import java.nio.file.Path
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+@DisplayName("`FieldAnnotator` should")
+internal class FieldAnnotatorSpec {
+
+    companion object : AnnotationPluginTestSetup() {
+
+        @BeforeAll
+        @JvmStatic
+        fun setup(@TempDir projectDir: Path) {
+            generateCode(projectDir)
+        }
+    }
+
+    @Nested inner class
+    `annotate field accessors` {
+
+        @Test
+        fun `in a message class and its builder`() {
+            val code = code("Carrier")
+            code shouldContain INTERNAL
+            // The annotation goes right above the accessors of the `value` field.
+            code.substringBefore("getValue") shouldContain INTERNAL
+        }
+
+        @Test
+        fun `in the 'MessageOrBuilder' interface`() {
+            code("CarrierOrBuilder") shouldContain INTERNAL
+        }
+
+        @Test
+        fun `of repeated fields`() {
+            val code = code("Carrier")
+            code.substringBefore("getTagsList") shouldContain BETA
+        }
+
+        @Test
+        fun `of map fields`() {
+            val code = code("Carrier")
+            code.substringBefore("getAttrsMap") shouldContain EXPERIMENTAL
+        }
+
+        @Test
+        fun `with several annotations for a field with several options`() {
+            val code = code("Carrier")
+            val beforeBoth = code.substringBefore("getBothBytes")
+            beforeBoth shouldContain INTERNAL
+            beforeBoth shouldContain BETA
+        }
+
+        @Test
+        fun `of fields enclosed in an outer class`() {
+            code("InternalFieldSingle") shouldContain INTERNAL
+        }
+    }
+
+    @Test
+    fun `not annotate accessors of fields without API level options`() {
+        // The `PlainOne` message has the `value` field with no options.
+        code("PlainOne") shouldNotContain INTERNAL
+    }
+
+    @Test
+    fun `not annotate accessors of a field with the option set to 'false'`() {
+        // The `off` field of the `Reverting` message has `(internal) = false`.
+        code("Reverting") shouldNotContain INTERNAL
+    }
+}

--- a/annotation-tests/src/test/kotlin/io/spine/tools/core/jvm/annotation/MessageAnnotatorSpec.kt
+++ b/annotation-tests/src/test/kotlin/io/spine/tools/core/jvm/annotation/MessageAnnotatorSpec.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.annotation
+
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldContainOnlyOnce
+import io.kotest.matchers.string.shouldNotContain
+import java.nio.file.Path
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+@DisplayName("`MessageAnnotator` should")
+internal class MessageAnnotatorSpec {
+
+    companion object : AnnotationPluginTestSetup() {
+
+        @BeforeAll
+        @JvmStatic
+        fun setup(@TempDir projectDir: Path) {
+            generateCode(projectDir)
+        }
+    }
+
+    @Nested inner class
+    `annotate top-level message classes` {
+
+        @Test
+        fun `with 'Internal' when '(internal_all) = true'`() {
+            code("Probe") shouldContain INTERNAL
+            code("Sonde") shouldContain INTERNAL
+        }
+
+        @Test
+        fun `with 'Beta' when '(beta_all) = true'`() {
+            code("BetaThing") shouldContain BETA
+        }
+
+        @Test
+        fun `with 'Experimental' when '(experimental_all) = true'`() {
+            code("ExperimentalThing") shouldContain EXPERIMENTAL
+        }
+
+        @Test
+        fun `with 'SPI' when '(SPI_all) = true'`() {
+            code("SpiMessage") shouldContain SPI_ANNOTATION
+        }
+    }
+
+    @Test
+    fun `annotate 'MessageOrBuilder' interfaces`() {
+        code("ProbeOrBuilder") shouldContain INTERNAL
+        code("BetaThingOrBuilder") shouldContain BETA
+    }
+
+    @Test
+    fun `annotate a message only once for semantically equal options`() {
+        code("DoubleMarked") shouldContainOnlyOnce INTERNAL
+    }
+
+    @Test
+    fun `not annotate messages without API level options`() {
+        code("PlainOne") shouldNotContain INTERNAL
+        code("PlainOne") shouldNotContain BETA
+    }
+
+    @Test
+    fun `not annotate a message reverting the file-wide option`() {
+        code("Reverting") shouldNotContain INTERNAL
+        code("RevertingOrBuilder") shouldNotContain INTERNAL
+    }
+
+    @Test
+    fun `not annotate types nested in an outer class annotated via the file-wide option`() {
+        val code = code("OuterInternal")
+        // The outer class itself carries the annotation...
+        code.substringBefore("class OuterInternal") shouldContain INTERNAL
+        // ...so the nested types do not repeat it.
+        code.substringAfter("class OuterInternal") shouldNotContain INTERNAL
+    }
+}

--- a/annotation-tests/src/test/kotlin/io/spine/tools/core/jvm/annotation/MethodPatternAnnotatorSpec.kt
+++ b/annotation-tests/src/test/kotlin/io/spine/tools/core/jvm/annotation/MethodPatternAnnotatorSpec.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.annotation
+
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import java.nio.file.Path
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+@DisplayName("`MethodPatternAnnotator` should")
+internal class MethodPatternAnnotatorSpec {
+
+    companion object : AnnotationPluginTestSetup(
+        internalMethodNames = listOf("getValue")
+    ) {
+
+        @BeforeAll
+        @JvmStatic
+        fun setup(@TempDir projectDir: Path) {
+            generateCode(projectDir)
+        }
+    }
+
+    @Test
+    fun `annotate methods matching a pattern as 'internal'`() {
+        val code = code("PlainOne")
+        code.substringBefore("getValue") shouldContain INTERNAL
+    }
+
+    @Test
+    fun `not annotate methods which do not match`() {
+        // The message has the `value` field, so only `getValue` must be annotated,
+        // and `getValueBytes` must stay intact.
+        val code = code("PlainOne")
+        val betweenAccessors = code
+            .substringAfter("getValue")
+            .substringBefore("getValueBytes")
+        betweenAccessors shouldNotContain INTERNAL
+    }
+
+    @Test
+    fun `not duplicate annotations added by other annotators`() {
+        // Accessors of the `value` field of `Carrier` are annotated by `FieldAnnotator`
+        // first. The method pattern matches `getValue`, and the annotator must skip it.
+        val code = code("Carrier")
+        code shouldNotContain Regex("${Regex.escape(INTERNAL)}\\s+${Regex.escape(INTERNAL)}")
+    }
+}

--- a/annotation-tests/src/test/kotlin/io/spine/tools/core/jvm/annotation/OuterClassAnnotatorSpec.kt
+++ b/annotation-tests/src/test/kotlin/io/spine/tools/core/jvm/annotation/OuterClassAnnotatorSpec.kt
@@ -24,35 +24,39 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+package io.spine.tools.core.jvm.annotation
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import java.nio.file.Path
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
+@DisplayName("`OuterClassAnnotator` should")
+internal class OuterClassAnnotatorSpec {
+
+    companion object : AnnotationPluginTestSetup() {
+
+        @BeforeAll
+        @JvmStatic
+        fun setup(@TempDir projectDir: Path) {
+            generateCode(projectDir)
+        }
+    }
+
+    @Test
+    fun `annotate the outer class of a single-file proto with a file-wide option`() {
+        val code = code("OuterInternal")
+        code shouldContain INTERNAL
+        // The annotation must precede the outer class declaration.
+        val outerClass = code.substringBefore("class OuterInternal")
+        outerClass shouldContain INTERNAL
+    }
+
+    @Test
+    fun `not annotate the outer class when the file-wide option is 'false'`() {
+        code("OuterReverting") shouldNotContain INTERNAL
     }
 }

--- a/annotation-tests/src/testFixtures/proto/given/annotation/beta_all_multiple.proto
+++ b/annotation-tests/src/testFixtures/proto/given/annotation/beta_all_multiple.proto
@@ -23,36 +23,16 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+syntax = "proto3";
 
-rootProject.name = "core-jvm-compiler"
+package given.annotation;
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import "spine/options.proto";
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
-    }
+option java_multiple_files = true;
+option (beta_all) = true;
+
+// A message which must get the `beta` annotation from the file-wide option.
+message BetaThing {
+    string value = 1;
 }

--- a/annotation-tests/src/testFixtures/proto/given/annotation/duplication.proto
+++ b/annotation-tests/src/testFixtures/proto/given/annotation/duplication.proto
@@ -23,36 +23,20 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+syntax = "proto3";
 
-rootProject.name = "core-jvm-compiler"
+package given.annotation;
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import "spine/options.proto";
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
-    }
+option java_multiple_files = true;
+option (internal_all) = true;
+
+// This message has the option which semantically repeats
+// the `(internal_all)` option set for the file.
+// It must be annotated only once.
+message DoubleMarked {
+    option (internal_type) = true;
+
+    string value = 1;
 }

--- a/annotation-tests/src/testFixtures/proto/given/annotation/experimental_all_multiple.proto
+++ b/annotation-tests/src/testFixtures/proto/given/annotation/experimental_all_multiple.proto
@@ -23,36 +23,16 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+syntax = "proto3";
 
-rootProject.name = "core-jvm-compiler"
+package given.annotation;
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import "spine/options.proto";
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
-    }
+option java_multiple_files = true;
+option (experimental_all) = true;
+
+// A message which must get the `experimental` annotation from the file-wide option.
+message ExperimentalThing {
+    string value = 1;
 }

--- a/annotation-tests/src/testFixtures/proto/given/annotation/internal_all_multiple.proto
+++ b/annotation-tests/src/testFixtures/proto/given/annotation/internal_all_multiple.proto
@@ -23,36 +23,32 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+syntax = "proto3";
 
-rootProject.name = "core-jvm-compiler"
+package given.annotation;
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import "spine/options.proto";
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
-    }
+option java_multiple_files = true;
+option (internal_all) = true;
+
+// A message which must get the `internal` annotation from the file-wide option.
+message Probe {
+    string value = 1;
+}
+
+// Another message in the same file.
+message Sonde {
+    string value = 1;
+}
+
+// An enum which must get the `internal` annotation from the file-wide option.
+enum Level {
+    LEVEL_UNDEFINED = 0;
+    HIGH = 1;
+}
+
+// A service declared in the file with the `internal_all` option.
+service Watching {
+    rpc Watch(Probe) returns (Sonde);
 }

--- a/annotation-tests/src/testFixtures/proto/given/annotation/internal_field.proto
+++ b/annotation-tests/src/testFixtures/proto/given/annotation/internal_field.proto
@@ -23,36 +23,29 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+syntax = "proto3";
 
-rootProject.name = "core-jvm-compiler"
+package given.annotation;
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import "spine/options.proto";
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
-    }
+option java_multiple_files = true;
+
+// A message with fields bearing API level options.
+message Carrier {
+
+    // Accessors of this field must be annotated as `internal`.
+    string value = 1 [(internal) = true];
+
+    // Accessors of this field must not be annotated.
+    string open = 2;
+
+    // Accessors of this repeated field must be annotated as `beta`.
+    repeated string tags = 3 [(beta) = true];
+
+    // Accessors of this map field must be annotated as `experimental`.
+    map<string, string> attrs = 4 [(experimental) = true];
+
+    // Accessors of this field must get both annotations.
+    string both = 5 [(internal) = true, (beta) = true];
 }

--- a/annotation-tests/src/testFixtures/proto/given/annotation/internal_field_single.proto
+++ b/annotation-tests/src/testFixtures/proto/given/annotation/internal_field_single.proto
@@ -23,36 +23,17 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+syntax = "proto3";
 
-rootProject.name = "core-jvm-compiler"
+package given.annotation;
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import "spine/options.proto";
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
-    }
+option java_multiple_files = false;
+
+// A message nested under the outer class with a field bearing the `internal` option.
+message Enclosed {
+
+    // Accessors of this field must be annotated as `internal`.
+    string value = 1 [(internal) = true];
 }

--- a/annotation-tests/src/testFixtures/proto/given/annotation/no_options.proto
+++ b/annotation-tests/src/testFixtures/proto/given/annotation/no_options.proto
@@ -23,36 +23,18 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+syntax = "proto3";
 
-rootProject.name = "core-jvm-compiler"
+package given.annotation;
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+option java_multiple_files = true;
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
-    }
+// A message without API level options. It must not be annotated.
+message PlainOne {
+    string value = 1;
+}
+
+// An enum without API level options. It must not be annotated.
+enum PlainLevel {
+    PLAIN_LEVEL_UNDEFINED = 0;
 }

--- a/annotation-tests/src/testFixtures/proto/given/annotation/no_options.proto
+++ b/annotation-tests/src/testFixtures/proto/given/annotation/no_options.proto
@@ -35,6 +35,12 @@ message PlainOne {
 }
 
 // An enum without API level options. It must not be annotated.
+//
+// The standard `deprecated` option makes the compiler dispatch
+// `EnumOptionDiscovered` for this enum, checking that non-API
+// options do not produce annotations.
 enum PlainLevel {
+    option deprecated = true;
+
     PLAIN_LEVEL_UNDEFINED = 0;
 }

--- a/annotation-tests/src/testFixtures/proto/given/annotation/outer_internal.proto
+++ b/annotation-tests/src/testFixtures/proto/given/annotation/outer_internal.proto
@@ -23,36 +23,22 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+syntax = "proto3";
 
-rootProject.name = "core-jvm-compiler"
+package given.annotation;
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import "spine/options.proto";
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
-    }
+// `java_multiple_files` is `false` by default; we set it for clarity.
+option java_multiple_files = false;
+option (internal_all) = true;
+
+// Messages below are nested under the outer class `OuterInternal`,
+// which must get the `internal` annotation.
+message Uno {
+    string value = 1;
+}
+
+message Dos {
+    string value = 1;
 }

--- a/annotation-tests/src/testFixtures/proto/given/annotation/outer_reverting.proto
+++ b/annotation-tests/src/testFixtures/proto/given/annotation/outer_reverting.proto
@@ -24,35 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+syntax = "proto3";
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+package given.annotation;
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
-    }
+import "spine/options.proto";
+
+option java_multiple_files = false;
+// The option is explicitly set to `false`, so the outer class `OuterReverting`
+// must not be annotated.
+option (internal_all) = false;
+
+message Withdrawn {
+    string value = 1;
 }

--- a/annotation-tests/src/testFixtures/proto/given/annotation/reverting.proto
+++ b/annotation-tests/src/testFixtures/proto/given/annotation/reverting.proto
@@ -24,35 +24,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+syntax = "proto3";
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+package given.annotation;
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
-    }
+import "spine/options.proto";
+
+option java_multiple_files = true;
+option (internal_all) = true;
+
+// This message overrides the `(internal_all)` option set for the file.
+message Reverting {
+    option (internal_type) = false;
+
+    string value = 1;
+
+    // Accessors of this field must not be annotated: the option is set to `false`.
+    string off = 2 [(internal) = false];
 }

--- a/annotation-tests/src/testFixtures/proto/given/annotation/spi_all.proto
+++ b/annotation-tests/src/testFixtures/proto/given/annotation/spi_all.proto
@@ -23,36 +23,21 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+syntax = "proto3";
 
-rootProject.name = "core-jvm-compiler"
+package given.annotation;
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import "spine/options.proto";
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
-    }
+option java_multiple_files = true;
+option (SPI_all) = true;
+
+// A message which must get the `SPI` annotation from the file-wide option.
+message SpiMessage {
+    string value = 1;
+}
+
+// A service declared in a file with the `SPI_all` option.
+service Watcher {
+    rpc Watch(SpiMessage) returns (SpiMessage);
 }

--- a/annotation-tests/src/testFixtures/proto/given/annotation/spi_service.proto
+++ b/annotation-tests/src/testFixtures/proto/given/annotation/spi_service.proto
@@ -23,36 +23,22 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+syntax = "proto3";
 
-rootProject.name = "core-jvm-compiler"
+package given.annotation;
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import "spine/options.proto";
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
-    }
+option java_multiple_files = true;
+
+// A request and response type for the service below.
+message Ping {
+    string value = 1;
+}
+
+// A service with the `SPI_service` option.
+service SpiServ {
+    option (SPI_service) = true;
+
+    rpc Serve(Ping) returns (Ping);
 }

--- a/annotation/build.gradle.kts
+++ b/annotation/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import io.spine.dependency.lib.Roaster
 import io.spine.dependency.local.Logging
 import io.spine.dependency.local.TestLib
 import io.spine.dependency.local.ToolBase
+import io.spine.gradle.report.coverage.creditTestCoverageFrom
 
 plugins {
     module
@@ -54,6 +55,14 @@ dependencies {
 }
 
 forceBaseInProtoTasks()
+
+/**
+ * The renderers and views of this module are exercised end-to-end by
+ * the `annotation-tests` module, which runs the Compiler pipeline in-process.
+ * Credit that coverage to this module's own Kover report, which otherwise
+ * sees only this module's `test` data.
+ */
+creditTestCoverageFrom(project(":annotation-tests"))
 
 /**
  * Tests use the artifacts published to `mavenLocal`, so we need to publish them all first.

--- a/annotation/src/main/kotlin/io/spine/tools/core/annotation/EnumAnnotationsView.kt
+++ b/annotation/src/main/kotlin/io/spine/tools/core/annotation/EnumAnnotationsView.kt
@@ -46,7 +46,7 @@ internal class EnumAnnotationsView : View<TypeName, EnumAnnotations, EnumAnnotat
     fun on(e: FileOptionMatched) = alter {
         file = e.file
         // If the option is already present at the enum level, do not overwrite it.
-        optionList.find { it.name == e.assumed.name }?.let {
+        if (optionList.any { it.name == e.assumed.name }) {
             return@alter
         }
         addOption(e.assumed)

--- a/annotation/src/main/kotlin/io/spine/tools/core/annotation/EnumAnnotationsView.kt
+++ b/annotation/src/main/kotlin/io/spine/tools/core/annotation/EnumAnnotationsView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,11 +44,22 @@ internal class EnumAnnotationsView : View<TypeName, EnumAnnotations, EnumAnnotat
 
     @Subscribe
     fun on(e: FileOptionMatched) = alter {
+        file = e.file
+        // If the option is already present at the enum level, do not overwrite it.
+        optionList.find { it.name == e.assumed.name }?.let {
+            return@alter
+        }
         addOption(e.assumed)
     }
 
     @Subscribe
     fun on(@External e: EnumOptionDiscovered) = alter {
+        file = e.file
+        // If the option was defined at the file level, overwrite it.
+        optionBuilderList.find { it.name == e.option.name }?.let {
+            it.value = e.option.value
+            return@alter
+        }
         addOption(e.option)
     }
 

--- a/annotation/src/main/kotlin/io/spine/tools/core/annotation/EnumAnnotationsView.kt
+++ b/annotation/src/main/kotlin/io/spine/tools/core/annotation/EnumAnnotationsView.kt
@@ -31,9 +31,7 @@ import io.spine.core.Subscribe
 import io.spine.tools.compiler.ast.TypeName
 import io.spine.tools.compiler.ast.event.EnumOptionDiscovered
 import io.spine.tools.compiler.plugin.View
-import io.spine.tools.compiler.plugin.ViewRepository
 import io.spine.server.entity.alter
-import io.spine.server.route.EventRouting
 import io.spine.server.route.Route
 import io.spine.tools.core.annotation.event.FileOptionMatched
 
@@ -70,17 +68,5 @@ internal class EnumAnnotationsView : View<TypeName, EnumAnnotations, EnumAnnotat
 
         @Route
         fun route(e: EnumOptionDiscovered) = e.subject.name
-    }
-
-    class Repository: ViewRepository<TypeName, EnumAnnotationsView, EnumAnnotations>() {
-
-        override fun setupEventRouting(routing: EventRouting<TypeName>) {
-            super.setupEventRouting(routing)
-            routing.route<FileOptionMatched> { e, _ ->
-                e.toEnumTypeName()
-            }.unicast<EnumOptionDiscovered> { e, _ ->
-                e.subject.name
-            }
-        }
     }
 }

--- a/annotation/src/main/kotlin/io/spine/tools/core/annotation/FileOptionsProcess.kt
+++ b/annotation/src/main/kotlin/io/spine/tools/core/annotation/FileOptionsProcess.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ import io.spine.tools.core.annotation.event.fileOptionMatched
 /**
  * Transforms options defined in a Protobuf file into [FileOptionMatched] events that match
  * a file-level option with an option for a corresponding Protobuf type such as
- * a message or a service defined in the file.
+ * a message, an enum, or a service defined in the file.
  *
  * @see io.spine.tools.core.annotation.event.FileOptionMatched
  */
@@ -99,6 +99,7 @@ private fun ProtobufSourceFile.addEvents(
     apiOption: ApiOption
 ) {
     addMessageEvents(events, fileOption, apiOption.messageOption)
+    addEnumEvents(events, fileOption, apiOption.messageOption)
     apiOption.serviceOption?.let { serviceOption ->
         addServiceEvents(events, fileOption, serviceOption)
     }
@@ -115,6 +116,22 @@ private fun ProtobufSourceFile.addMessageEvents(
             file = thisSource.file
             this.fileOption = fileOption
             this@fileOptionMatched.messageType = message.name
+            assumed = typeOption
+        })
+    }
+}
+
+private fun ProtobufSourceFile.addEnumEvents(
+    events: MutableList<FileOptionMatched>,
+    fileOption: Option,
+    typeOption: Option
+) {
+    val thisSource = this
+    enumTypeMap.values.forEach { enumType ->
+        events.add(fileOptionMatched {
+            file = thisSource.file
+            this.fileOption = fileOption
+            this@fileOptionMatched.enumType = enumType.name
             assumed = typeOption
         })
     }

--- a/annotation/src/main/kotlin/io/spine/tools/core/annotation/MessageAnnotationsView.kt
+++ b/annotation/src/main/kotlin/io/spine/tools/core/annotation/MessageAnnotationsView.kt
@@ -64,7 +64,7 @@ internal class MessageAnnotationsView :
     fun on(e: FileOptionMatched) = alter {
         file = e.file
         // If the option is already present at the message level, do not overwrite it.
-        optionList.find { it.name == e.assumed.name }?.let {
+        if (optionList.any { it.name == e.assumed.name }) {
             return@alter
         }
         addOption(e.assumed)

--- a/annotation/src/main/kotlin/io/spine/tools/core/annotation/ServiceAnnotationsView.kt
+++ b/annotation/src/main/kotlin/io/spine/tools/core/annotation/ServiceAnnotationsView.kt
@@ -61,7 +61,7 @@ internal class ServiceAnnotationsView :
     fun on(e: FileOptionMatched) = alter {
         file = e.file
         // If the option is already present at the service level, do not overwrite it.
-        optionList.find { it.name == e.assumed.name }?.let {
+        if (optionList.any { it.name == e.assumed.name }) {
             return@alter
         }
         addOption(e.assumed)

--- a/annotation/src/main/kotlin/io/spine/tools/core/jvm/annotation/FieldAnnotator.kt
+++ b/annotation/src/main/kotlin/io/spine/tools/core/jvm/annotation/FieldAnnotator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import io.spine.tools.compiler.jvm.MessageOrEnumConvention
 import io.spine.tools.core.annotation.ApiOption
 import io.spine.tools.core.annotation.FieldOptions
 import io.spine.tools.core.annotation.MessageFieldAnnotations
+import io.spine.tools.core.annotation.isTrue
 import io.spine.tools.java.reference
 
 /**
@@ -61,7 +62,9 @@ internal class FieldAnnotator :
         fieldOption: FieldOptions
     ) {
         val messageType = typeSystem.findMessage(view.type)!!.first
-        fieldOption.optionList.forEach { option ->
+        // Options with the `false` value do not produce annotations.
+        val enabledOptions = fieldOption.optionList.filter { it.value.isTrue() }
+        enabledOptions.forEach { option ->
             val apiOption = ApiOption.findMatching(option)
             check(apiOption != null) {
                 "Unable to find an API option for `${option.name}`."

--- a/annotation/src/main/kotlin/io/spine/tools/core/jvm/annotation/MessageOrEnumAnnotator.kt
+++ b/annotation/src/main/kotlin/io/spine/tools/core/jvm/annotation/MessageOrEnumAnnotator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import io.spine.tools.compiler.jvm.MessageOrEnumConvention
 import io.spine.tools.compiler.jvm.javaMultipleFiles
 import io.spine.tools.core.annotation.ApiOption
 import io.spine.tools.core.annotation.WithOptions
+import io.spine.tools.core.annotation.isTrue
 
 /**
  * An abstract base for annotators of message types and enums.
@@ -49,7 +50,13 @@ internal sealed class MessageOrEnumAnnotator<T>(viewClass: Class<T>) :
 
     override fun needsAnnotation(apiOption: ApiOption, header: ProtoFileHeader): Boolean {
         val singleFile = !header.javaMultipleFiles()
-        val alreadyInHeader = header.optionList.contains(apiOption.fileOption)
+        // Compiler-produced options carry extra fields such as the option field
+        // number, so match by the name and the value instead of comparing
+        // whole `Option` instances.
+        val fileOption = apiOption.fileOption
+        val alreadyInHeader = header.optionList.any {
+            it.name == fileOption.name && it.value.isTrue()
+        }
         return !(singleFile && alreadyInHeader)
     }
 }

--- a/annotation/src/main/kotlin/io/spine/tools/core/jvm/annotation/OuterClassAnnotationDiscovery.kt
+++ b/annotation/src/main/kotlin/io/spine/tools/core/jvm/annotation/OuterClassAnnotationDiscovery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import io.spine.server.procman.ProcessManager
 import io.spine.server.procman.ProcessManagerRepository
 import io.spine.server.route.EventRouting
 import io.spine.tools.core.annotation.ApiOption.Companion.findMatching
+import io.spine.tools.core.annotation.isTrue
 
 /**
  * A process manager which discovers the API annotation options set on the outer
@@ -55,16 +56,17 @@ internal class OuterClassAnnotationDiscovery:
             alter {
                 file = e.file
                 header = e.header
-                e.header.optionList.mapNotNull {
-                    findMatching(it)
-                }.forEach {
-                    // We care here only about the message options because service options
-                    // are handled by `ServiceAnnotationsView`, and gRPC services are top
-                    // level classes anyway. Using the message option would trigger
-                    // the annotation that would have been added to a message class if it
-                    // were a top level.
-                    addOption(it.messageOption)
-                }
+                e.header.optionList
+                    .filter { it.value.isTrue() }
+                    .mapNotNull { findMatching(it) }
+                    .forEach {
+                        // We care here only about the message options because service options
+                        // are handled by `ServiceAnnotationsView`, and gRPC services are top
+                        // level classes anyway. Using the message option would trigger
+                        // the annotation that would have been added to a message class if it
+                        // were a top level.
+                        addOption(it.messageOption)
+                    }
             }
         }
         return noReaction()

--- a/annotation/src/main/kotlin/io/spine/tools/core/jvm/annotation/OuterClassAnnotationDiscovery.kt
+++ b/annotation/src/main/kotlin/io/spine/tools/core/jvm/annotation/OuterClassAnnotationDiscovery.kt
@@ -50,8 +50,9 @@ internal class OuterClassAnnotationDiscovery:
 
     @React
     fun on(@External e: FileEntered): NoReaction {
-        // The check here is a safety net. We should get only events for
-        // proto files with `java_multiple_files` set to `true`. See `Repository.setEventRouting`.
+        // The check here is a safety net. We should get only events for proto
+        // files with `java_multiple_files` set to `false`, for which a single
+        // outer class is generated. See `Repository.setupEventRouting`.
         if (!e.header.javaMultipleFiles()) {
             alter {
                 file = e.file

--- a/annotation/src/main/kotlin/io/spine/tools/core/jvm/annotation/TypeAnnotator.kt
+++ b/annotation/src/main/kotlin/io/spine/tools/core/jvm/annotation/TypeAnnotator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import io.spine.tools.compiler.context.findHeader
 import io.spine.tools.core.annotation.ApiOption
 import io.spine.tools.core.annotation.WithOptions
 import io.spine.tools.core.annotation.file
+import io.spine.tools.core.annotation.isTrue
 import io.spine.tools.core.annotation.optionList
 
 /**
@@ -42,9 +43,16 @@ internal abstract class TypeAnnotator<T>(
     viewClass: Class<T>
 ): ProtoAnnotator<T>(viewClass) where T : EntityState<*>, T : WithOptions {
 
+    /**
+     * Annotates the type in accordance with the API level options of the given view.
+     *
+     * Options with the `false` value are skipped. Setting an API option to `false`
+     * reverts the effect of the corresponding file-wide option, if any.
+     */
     @OverridingMethodsMustInvokeSuper
     override fun annotate(view: T) {
         view.optionList
+            .filter { it.value.isTrue() }
             .mapNotNull { ApiOption.findMatching(it) }
             .filter {
                 val header = findHeader(view.file)!!

--- a/annotation/src/test/kotlin/io/spine/tools/core/annotation/ApiOptionSpec.kt
+++ b/annotation/src/test/kotlin/io/spine/tools/core/annotation/ApiOptionSpec.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.annotation
+
+import com.google.protobuf.BoolValue
+import com.google.protobuf.StringValue
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.spine.protobuf.pack
+import io.spine.tools.core.annotation.given.apiOption
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("`ApiOption` should")
+internal class ApiOptionSpec {
+
+    @Test
+    fun `declare file and message options for all API levels`() {
+        ApiOption.BETA.fileOption.name shouldBe "beta_all"
+        ApiOption.BETA.messageOption.name shouldBe "beta_type"
+        ApiOption.BETA.fieldOption?.name shouldBe "beta"
+
+        ApiOption.EXPERIMENTAL.fileOption.name shouldBe "experimental_all"
+        ApiOption.EXPERIMENTAL.messageOption.name shouldBe "experimental_type"
+        ApiOption.EXPERIMENTAL.fieldOption?.name shouldBe "experimental"
+
+        ApiOption.INTERNAL.fileOption.name shouldBe "internal_all"
+        ApiOption.INTERNAL.messageOption.name shouldBe "internal_type"
+        ApiOption.INTERNAL.fieldOption?.name shouldBe "internal"
+
+        ApiOption.SPI.fileOption.name shouldBe "SPI_all"
+        ApiOption.SPI.messageOption.name shouldBe "SPI_type"
+        ApiOption.SPI.serviceOption?.name shouldBe "SPI_service"
+    }
+
+    @Test
+    fun `not declare options which do not exist at a level`() {
+        ApiOption.SPI.fieldOption.shouldBeNull()
+        ApiOption.BETA.serviceOption.shouldBeNull()
+        ApiOption.EXPERIMENTAL.serviceOption.shouldBeNull()
+        ApiOption.INTERNAL.serviceOption.shouldBeNull()
+    }
+
+    @Nested inner class
+    `find a matching option` {
+
+        private fun byName(name: String) = ApiOption.findMatching(apiOption(name))
+
+        @Test
+        fun `by a file-level option name`() {
+            byName("beta_all") shouldBe ApiOption.BETA
+            byName("internal_all") shouldBe ApiOption.INTERNAL
+        }
+
+        @Test
+        fun `by a message-level option name`() {
+            byName("experimental_type") shouldBe ApiOption.EXPERIMENTAL
+            byName("SPI_type") shouldBe ApiOption.SPI
+        }
+
+        @Test
+        fun `by a field-level option name`() {
+            byName("beta") shouldBe ApiOption.BETA
+            byName("experimental") shouldBe ApiOption.EXPERIMENTAL
+            byName("internal") shouldBe ApiOption.INTERNAL
+        }
+
+        @Test
+        fun `by a service-level option name`() {
+            byName("SPI_service") shouldBe ApiOption.SPI
+        }
+
+        @Test
+        fun `returning 'null' for a non-API option`() {
+            byName("deprecated").shouldBeNull()
+        }
+    }
+
+    @Nested inner class
+    `tell if an option value is 'true'` {
+
+        @Test
+        fun `for a packed 'true' value`() {
+            BoolValue.of(true).pack().isTrue().shouldBeTrue()
+        }
+
+        @Test
+        fun `for a packed 'false' value`() {
+            BoolValue.of(false).pack().isTrue().shouldBeFalse()
+        }
+
+        @Test
+        fun `for a non-boolean value`() {
+            StringValue.of("yes").pack().isTrue().shouldBeFalse()
+        }
+    }
+}

--- a/annotation/src/test/kotlin/io/spine/tools/core/annotation/EnumAnnotationsViewSpec.kt
+++ b/annotation/src/test/kotlin/io/spine/tools/core/annotation/EnumAnnotationsViewSpec.kt
@@ -24,35 +24,37 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+package io.spine.tools.core.annotation
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import io.kotest.matchers.shouldBe
+import io.spine.tools.compiler.ast.enumType
+import io.spine.tools.compiler.ast.event.enumOptionDiscovered
+import io.spine.tools.core.annotation.given.apiOption
+import io.spine.tools.core.annotation.given.enumName
+import io.spine.tools.core.annotation.given.fileOptionMatchedWithEnum
+import io.spine.tools.core.annotation.given.testFile
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
+@DisplayName("`EnumAnnotationsView` should route")
+internal class EnumAnnotationsViewSpec {
+
+    @Test
+    fun `'FileOptionMatched' to the target enum type`() {
+        val event = fileOptionMatchedWithEnum()
+        EnumAnnotationsView.route(event) shouldBe setOf(enumName)
+    }
+
+    @Test
+    fun `'EnumOptionDiscovered' to the subject type`() {
+        val event = enumOptionDiscovered {
+            file = testFile
+            subject = enumType {
+                name = enumName
+                file = testFile
+            }
+            option = apiOption("deprecated")
+        }
+        EnumAnnotationsView.route(event) shouldBe enumName
     }
 }

--- a/annotation/src/test/kotlin/io/spine/tools/core/annotation/MessageAnnotationsViewSpec.kt
+++ b/annotation/src/test/kotlin/io/spine/tools/core/annotation/MessageAnnotationsViewSpec.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.annotation
+
+import io.kotest.matchers.shouldBe
+import io.spine.tools.compiler.ast.event.fieldOptionDiscovered
+import io.spine.tools.compiler.ast.event.messageOptionDiscovered
+import io.spine.tools.compiler.ast.messageType
+import io.spine.tools.core.annotation.given.apiOption
+import io.spine.tools.core.annotation.given.stringField
+import io.spine.tools.core.annotation.given.fileOptionMatchedWithMessage
+import io.spine.tools.core.annotation.given.messageName
+import io.spine.tools.core.annotation.given.testFile
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`MessageAnnotationsView` should route")
+internal class MessageAnnotationsViewSpec {
+
+    @Test
+    fun `'FileOptionMatched' to the target message type`() {
+        val event = fileOptionMatchedWithMessage()
+        MessageAnnotationsView.route(event) shouldBe setOf(messageName)
+    }
+
+    @Test
+    fun `'MessageOptionDiscovered' to the subject type`() {
+        val event = messageOptionDiscovered {
+            file = testFile
+            subject = messageType {
+                name = messageName
+                file = testFile
+            }
+            option = apiOption("internal_type")
+        }
+        MessageAnnotationsView.route(event) shouldBe messageName
+    }
+
+    @Test
+    fun `'FieldOptionDiscovered' to the declaring type`() {
+        val event = fieldOptionDiscovered {
+            file = testFile
+            subject = stringField("value", messageName)
+            option = apiOption("internal")
+        }
+        MessageAnnotationsView.route(event) shouldBe messageName
+    }
+}

--- a/annotation/src/test/kotlin/io/spine/tools/core/annotation/MessageFieldAnnotationsViewSpec.kt
+++ b/annotation/src/test/kotlin/io/spine/tools/core/annotation/MessageFieldAnnotationsViewSpec.kt
@@ -24,35 +24,35 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+package io.spine.tools.core.annotation
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.spine.tools.compiler.ast.event.FieldOptionDiscovered
+import io.spine.tools.compiler.ast.event.fieldOptionDiscovered
+import io.spine.tools.core.annotation.given.apiOption
+import io.spine.tools.core.annotation.given.stringField
+import io.spine.tools.core.annotation.given.messageName
+import io.spine.tools.core.annotation.given.testFile
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
+@DisplayName("`MessageFieldAnnotationsView` should route")
+internal class MessageFieldAnnotationsViewSpec {
+
+    private fun event(optionName: String): FieldOptionDiscovered = fieldOptionDiscovered {
+        file = testFile
+        subject = stringField("value", messageName)
+        option = apiOption(optionName)
+    }
+
+    @Test
+    fun `an API option to the declaring type`() {
+        MessageFieldAnnotationsView.route(event("internal")) shouldBe setOf(messageName)
+    }
+
+    @Test
+    fun `a non-API option to no targets`() {
+        MessageFieldAnnotationsView.route(event("deprecated")).shouldBeEmpty()
     }
 }

--- a/annotation/src/test/kotlin/io/spine/tools/core/annotation/RoutingExtsSpec.kt
+++ b/annotation/src/test/kotlin/io/spine/tools/core/annotation/RoutingExtsSpec.kt
@@ -24,28 +24,37 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.tools.core.jvm.annotation
+package io.spine.tools.core.annotation
 
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
-import io.spine.tools.core.annotation.ApiAnnotationsPlugin
+import io.spine.tools.core.annotation.given.enumName
+import io.spine.tools.core.annotation.given.fileOptionMatchedWithEnum
+import io.spine.tools.core.annotation.given.fileOptionMatchedWithMessage
+import io.spine.tools.core.annotation.given.fileOptionMatchedWithService
+import io.spine.tools.core.annotation.given.messageName
+import io.spine.tools.core.annotation.given.serviceTestName
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
-@DisplayName("`ApiAnnotationsPlugin` should")
-internal class ApiAnnotationsPluginSpec {
+@DisplayName("Routing extensions for `FileOptionMatched` should")
+internal class RoutingExtsSpec {
 
     @Test
-    fun `provide views and renderers`() {
-        val plugin = ApiAnnotationsPlugin()
-        plugin shouldNotBe null
-        plugin.views.size shouldNotBe 0
-        plugin.renderers.size shouldNotBe 0
+    fun `route to a message type`() {
+        fileOptionMatchedWithMessage().toMessageTypeName() shouldBe setOf(messageName)
+        fileOptionMatchedWithEnum().toMessageTypeName().shouldBeEmpty()
     }
 
     @Test
-    fun `expose the settings ID`() {
-        ApiAnnotationsPlugin.SETTINGS_ID shouldBe
-                "io.spine.tools.core.annotation.ApiAnnotationsPlugin"
+    fun `route to an enum type`() {
+        fileOptionMatchedWithEnum().toEnumTypeName() shouldBe setOf(enumName)
+        fileOptionMatchedWithMessage().toEnumTypeName().shouldBeEmpty()
+    }
+
+    @Test
+    fun `route to a service`() {
+        fileOptionMatchedWithService().toServiceName() shouldBe setOf(serviceTestName)
+        fileOptionMatchedWithMessage().toServiceName().shouldBeEmpty()
     }
 }

--- a/annotation/src/test/kotlin/io/spine/tools/core/annotation/ServiceAnnotationsViewSpec.kt
+++ b/annotation/src/test/kotlin/io/spine/tools/core/annotation/ServiceAnnotationsViewSpec.kt
@@ -24,35 +24,37 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+package io.spine.tools.core.annotation
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import io.kotest.matchers.shouldBe
+import io.spine.tools.compiler.ast.event.serviceOptionDiscovered
+import io.spine.tools.compiler.ast.service
+import io.spine.tools.core.annotation.given.apiOption
+import io.spine.tools.core.annotation.given.fileOptionMatchedWithService
+import io.spine.tools.core.annotation.given.serviceTestName
+import io.spine.tools.core.annotation.given.testFile
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
+@DisplayName("`ServiceAnnotationsView` should route")
+internal class ServiceAnnotationsViewSpec {
+
+    @Test
+    fun `'FileOptionMatched' to the target service`() {
+        val event = fileOptionMatchedWithService()
+        ServiceAnnotationsView.route(event) shouldBe setOf(serviceTestName)
+    }
+
+    @Test
+    fun `'ServiceOptionDiscovered' to the subject service`() {
+        val event = serviceOptionDiscovered {
+            file = testFile
+            subject = service {
+                name = serviceTestName
+                file = testFile
+            }
+            option = apiOption("SPI_service")
+        }
+        ServiceAnnotationsView.route(event) shouldBe serviceTestName
     }
 }

--- a/annotation/src/test/kotlin/io/spine/tools/core/annotation/WithOptionsSpec.kt
+++ b/annotation/src/test/kotlin/io/spine/tools/core/annotation/WithOptionsSpec.kt
@@ -24,35 +24,36 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+package io.spine.tools.core.annotation
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import io.kotest.matchers.shouldBe
+import io.spine.tools.compiler.ast.File
+import io.spine.tools.compiler.ast.Option
+import io.spine.tools.core.annotation.given.apiOption
+import io.spine.tools.core.annotation.given.testFile
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
+@DisplayName("Extensions for `WithOptions` should")
+internal class WithOptionsSpec {
+
+    private val options = listOf(apiOption("internal_all"))
+
+    /**
+     * A stub implementation backed by fixed values.
+     */
+    private val withOptions = object : WithOptions {
+        override fun getOptionList(): List<Option> = options
+        override fun getFile(): File = testFile
+    }
+
+    @Test
+    fun `provide a shortcut for the option list`() {
+        withOptions.optionList shouldBe options
+    }
+
+    @Test
+    fun `provide a shortcut for the file`() {
+        withOptions.file shouldBe testFile
     }
 }

--- a/annotation/src/test/kotlin/io/spine/tools/core/annotation/given/GivenEvents.kt
+++ b/annotation/src/test/kotlin/io/spine/tools/core/annotation/given/GivenEvents.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.annotation.given
+
+import com.google.protobuf.BoolValue
+import io.spine.protobuf.pack
+import io.spine.tools.compiler.ast.Field
+import io.spine.tools.compiler.ast.Option
+import io.spine.tools.compiler.ast.PrimitiveType
+import io.spine.tools.compiler.ast.ServiceName
+import io.spine.tools.compiler.ast.TypeInstances
+import io.spine.tools.compiler.ast.TypeName
+import io.spine.tools.compiler.ast.field
+import io.spine.tools.compiler.ast.fieldName
+import io.spine.tools.compiler.ast.fieldType
+import io.spine.tools.compiler.ast.file
+import io.spine.tools.compiler.ast.option
+import io.spine.tools.compiler.ast.serviceName
+import io.spine.tools.compiler.ast.typeName
+import io.spine.tools.core.annotation.event.FileOptionMatched
+import io.spine.tools.core.annotation.event.fileOptionMatched
+
+/**
+ * Creates a boolean option with the given name and the `true` value.
+ */
+internal fun apiOption(name: String): Option = option {
+    this.name = name
+    type = TypeInstances.boolean
+    value = BoolValue.of(true).pack()
+}
+
+/**
+ * Creates a `string` field with the given name declared in the given type.
+ */
+internal fun stringField(name: String, declaredIn: TypeName): Field = field {
+    this.name = fieldName { value = name }
+    declaringType = declaredIn
+    type = fieldType { primitive = PrimitiveType.TYPE_STRING }
+}
+
+/**
+ * The proto file used by the test events.
+ */
+internal val testFile = file {
+    path = "given/annotation/test_types.proto"
+}
+
+/**
+ * The name of a message type used by the test events.
+ */
+internal val messageName: TypeName = typeName {
+    packageName = "given.annotation"
+    simpleName = "TestMessage"
+}
+
+/**
+ * The name of an enum type used by the test events.
+ */
+internal val enumName: TypeName = typeName {
+    packageName = "given.annotation"
+    simpleName = "TestEnum"
+}
+
+/**
+ * The name of a service used by the test events.
+ */
+internal val serviceTestName: ServiceName = serviceName {
+    packageName = "given.annotation"
+    simpleName = "TestService"
+}
+
+/**
+ * Creates a [FileOptionMatched] event with the message type as the target.
+ */
+internal fun fileOptionMatchedWithMessage(): FileOptionMatched = fileOptionMatched {
+    file = testFile
+    fileOption = apiOption("internal_all")
+    messageType = messageName
+    assumed = apiOption("internal_type")
+}
+
+/**
+ * Creates a [FileOptionMatched] event with the enum type as the target.
+ */
+internal fun fileOptionMatchedWithEnum(): FileOptionMatched = fileOptionMatched {
+    file = testFile
+    fileOption = apiOption("internal_all")
+    enumType = enumName
+    assumed = apiOption("internal_type")
+}
+
+/**
+ * Creates a [FileOptionMatched] event with the service as the target.
+ */
+internal fun fileOptionMatchedWithService(): FileOptionMatched = fileOptionMatched {
+    file = testFile
+    fileOption = apiOption("SPI_all")
+    service = serviceTestName
+    assumed = apiOption("SPI_service")
+}

--- a/annotation/src/test/kotlin/io/spine/tools/core/jvm/annotation/ApiAnnotationsPluginIgTest.kt
+++ b/annotation/src/test/kotlin/io/spine/tools/core/jvm/annotation/ApiAnnotationsPluginIgTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -286,9 +286,13 @@ internal class ApiAnnotationsPluginIgTest {
         fun `gRPC services if service option is false`() =
             checkServiceAnnotations(GivenProtoFile.NO_INTERNAL_OPTIONS, Internal::class.java, false)
 
+        /**
+         * The `reverting.proto` file declares `java_multiple_files = true`, so
+         * the message classes are top-level, and we check them directly.
+         */
         @Test
         fun `if message option overrides file option`() =
-            checkNestedTypesAnnotations(GivenProtoFile.REVERTING, Internal::class.java, false)
+            checkTypeAnnotations(GivenProtoFile.REVERTING, Internal::class.java, false)
     }
 
     @Test

--- a/annotation/src/test/kotlin/io/spine/tools/core/jvm/annotation/FieldAccessorsSpec.kt
+++ b/annotation/src/test/kotlin/io/spine/tools/core/jvm/annotation/FieldAccessorsSpec.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.annotation
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.spine.tools.compiler.ast.fieldName
+import io.spine.tools.compiler.jvm.ClassName
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`FieldAccessors` should")
+internal class FieldAccessorsSpec {
+
+    private val className = ClassName("given.test", "Sample")
+    private val field = fieldName { value = "my_field" }
+    private val insertionPoint = FieldAccessors(className, field)
+
+    private val code = """
+        package given.test;
+
+        public class Sample {
+
+            public String getMyField() { return ""; }
+
+            public Sample setMyField(String value) { return this; }
+
+            public int getOther() { return 0; }
+        }
+        """.trimIndent()
+
+    @Test
+    fun `have no label`() {
+        insertionPoint.label shouldBe ""
+    }
+
+    @Test
+    fun `locate all accessor methods of the field`() {
+        insertionPoint.locate(code) shouldHaveSize 2
+    }
+
+    @Test
+    fun `fail when the class is not present in the code`() {
+        val otherClass = FieldAccessors(ClassName("given.test", "Missing"), field)
+        val exception = shouldThrow<IllegalStateException> {
+            otherClass.locate(code)
+        }
+        exception.message shouldContain "Unable to find the class"
+    }
+
+    @Test
+    fun `fail when the field has no accessors`() {
+        val unknownField = FieldAccessors(className, fieldName { value = "unknown_field" })
+        val exception = shouldThrow<IllegalStateException> {
+            unknownField.locate(code)
+        }
+        exception.message shouldContain "Unable to find getter(s)"
+    }
+}

--- a/base/build.gradle.kts
+++ b/base/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,6 +100,10 @@ dependencies {
 
     testImplementation(TestLib.lib)
     testImplementation(gradleTestKit())
+    testImplementation(gradleKotlinDsl())?.because(
+        "Production code uses Gradle Kotlin DSL extensions (e.g. in `ModuleOptions`)," +
+                " which are `compileOnly` and thus needed on the test runtime classpath."
+    )
     testImplementation(ToolBase.pluginTestlib)
 }
 

--- a/base/build.gradle.kts
+++ b/base/build.gradle.kts
@@ -32,6 +32,7 @@ import io.spine.dependency.local.Logging
 import io.spine.dependency.local.TestLib
 import io.spine.dependency.local.ToolBase
 import io.spine.dependency.local.Validation
+import io.spine.gradle.report.coverage.creditTestCoverageFrom
 
 plugins {
     module
@@ -108,3 +109,8 @@ dependencies {
 }
 
 forceSpineBase()
+
+/**
+ * Add coverage of the `AddFieldClass` from the integration tests executed the referenced project.
+ */
+creditTestCoverageFrom(project(":entity-tests"))

--- a/base/src/main/kotlin/io/spine/tools/core/jvm/GeneratedAnnotation.kt
+++ b/base/src/main/kotlin/io/spine/tools/core/jvm/GeneratedAnnotation.kt
@@ -77,7 +77,7 @@ public object GeneratedAnnotation {
      */
     public fun forJavaPoet(value: String = defaultValue): JAnnotationSpec =
         JAnnotationSpec.builder(Generated::class.java)
-            .addMember("value", "\"\$L\"", value)
+            .addMember("value", "\$S", value)
             .build()
 
     /**
@@ -88,6 +88,6 @@ public object GeneratedAnnotation {
      */
     public fun forKotlinPoet(value: String = defaultValue): KAnnotationSpec =
         KAnnotationSpec.builder(Generated::class)
-            .addMember("\"%L\"", value)
+            .addMember("%S", value)
             .build()
 }

--- a/base/src/main/kotlin/io/spine/tools/core/jvm/GeneratedAnnotation.kt
+++ b/base/src/main/kotlin/io/spine/tools/core/jvm/GeneratedAnnotation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,9 +77,8 @@ public object GeneratedAnnotation {
      */
     public fun forJavaPoet(value: String = defaultValue): JAnnotationSpec =
         JAnnotationSpec.builder(Generated::class.java)
-            .addMember("value", "\"%L\"", value)
+            .addMember("value", "\"\$L\"", value)
             .build()
-
 
     /**
      * Creates a new [PsiAnnotation] with the [Generated] annotation.

--- a/base/src/main/kotlin/io/spine/tools/core/jvm/gradle/module/ModuleOptions.kt
+++ b/base/src/main/kotlin/io/spine/tools/core/jvm/gradle/module/ModuleOptions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ public abstract class ModuleOptions @Inject constructor(private val project: Pro
             ModuleKind.SERVER -> CoreJvm.server
             ModuleKind.CLIENT -> CoreJvm.client
         }
-        project.dependencies.add("implementation", dependency)
+        project.dependencies.add("implementation", dependency.artifact.coordinates)
     }
 }
 

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/GeneratedAnnotationSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/GeneratedAnnotationSpec.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm
+
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`GeneratedAnnotation` should")
+internal class GeneratedAnnotationSpec {
+
+    private val annotationType = "io.spine.annotation.Generated"
+
+    @Test
+    fun `create a PSI annotation with a custom value`() {
+        val annotation = GeneratedAnnotation.forPsi("custom value")
+        annotation.text shouldContain annotationType
+        annotation.text shouldContain "\"custom value\""
+    }
+
+    @Test
+    fun `create a PSI annotation referring to the compiler version by default`() {
+        val annotation = GeneratedAnnotation.forPsi()
+        annotation.text shouldContain "by Spine CoreJvm Compiler"
+    }
+
+    @Test
+    fun `create a JavaPoet annotation spec`() {
+        val spec = GeneratedAnnotation.forJavaPoet("javapoet value")
+        spec.toString() shouldContain annotationType
+        spec.toString() shouldContain "\"javapoet value\""
+    }
+
+    @Test
+    fun `create a KotlinPoet annotation spec`() {
+        val spec = GeneratedAnnotation.forKotlinPoet("kotlinpoet value")
+        spec.toString() shouldContain "Generated"
+        spec.toString() shouldContain "kotlinpoet value"
+    }
+}

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/OverrideAnnotationSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/OverrideAnnotationSpec.kt
@@ -24,35 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+package io.spine.tools.core.jvm
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
+@DisplayName("`OverrideAnnotation` should")
+internal class OverrideAnnotationSpec {
+
+    @Test
+    fun `create a PSI annotation for 'Override'`() {
+        OverrideAnnotation.create().text shouldBe "@Override"
     }
 }

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/VersionHolderSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/VersionHolderSpec.kt
@@ -24,35 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+package io.spine.tools.core.jvm
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import io.kotest.matchers.string.shouldNotBeBlank
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
+@DisplayName("`VersionHolder` should")
+internal class VersionHolderSpec {
+
+    @Test
+    fun `load the version of the compiler`() {
+        VersionHolder.version.value.shouldNotBeBlank()
     }
 }

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/base/FieldPathExtsSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/base/FieldPathExtsSpec.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.base
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.spine.base.fieldPath
+import io.spine.tools.compiler.protobuf.toMessageType
+import io.spine.tools.core.jvm.field.given.farmTypeSystem
+import io.spine.tools.core.jvm.given.base.Farm
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("Extensions for `FieldPath` should")
+internal class FieldPathExtsSpec {
+
+    private val typeSystem = farmTypeSystem()
+    private val farm = Farm.getDescriptor().toMessageType()
+
+    private fun path(vararg names: String) = fieldPath {
+        fieldName.addAll(names.toList())
+    }
+
+    @Nested inner class
+    `tell if a path is not nested` {
+
+        @Test
+        fun `for a single-element path`() {
+            path("name").isNotNested.shouldBeTrue()
+        }
+
+        @Test
+        fun `for a multi-element path`() {
+            path("barn", "title").isNotNested.shouldBeFalse()
+        }
+    }
+
+    @Test
+    fun `join the path with dots`() {
+        path("barn", "stall", "id").joined shouldBe "barn.stall.id"
+    }
+
+    @Nested inner class
+    `obtain the root field name` {
+
+        @Test
+        fun `of a non-empty path`() {
+            path("barn", "title").root shouldBe "barn"
+        }
+
+        @Test
+        fun `rejecting an empty path`() {
+            shouldThrow<NoSuchElementException> {
+                path().root
+            }
+        }
+    }
+
+    @Nested inner class
+    `resolve a field path` {
+
+        @Test
+        fun `pointing to a direct field`() {
+            val field = typeSystem.resolve(path("name"), farm)
+            field.name.value shouldBe "name"
+        }
+
+        @Test
+        fun `pointing to a nested field`() {
+            val field = typeSystem.resolve(path("barn", "stall", "id"), farm)
+            field.name.value shouldBe "id"
+        }
+
+        @Test
+        fun `rejecting a path through a non-message field`() {
+            val exception = shouldThrow<IllegalStateException> {
+                typeSystem.resolve(path("name", "whatever"), farm)
+            }
+            exception.message shouldContain "doesn't denote a message"
+        }
+
+        @Test
+        fun `rejecting a path through an unknown message type`() {
+            val exception = shouldThrow<IllegalStateException> {
+                typeSystem.resolve(path("built", "seconds"), farm)
+            }
+            exception.message shouldContain "was not found"
+        }
+    }
+}

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/field/AccessorSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/field/AccessorSpec.kt
@@ -24,35 +24,33 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+package io.spine.tools.core.jvm.field
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import com.google.common.testing.EqualsTester
+import io.kotest.matchers.shouldBe
+import io.spine.testing.ClassTest
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
+@DisplayName("`Accessor` should")
+internal class AccessorSpec : ClassTest<Accessor>(Accessor::class.java) {
+
+    @Test
+    fun `create a prefix-only template`() {
+        Accessor.prefix("get").toString() shouldBe "get%s"
+    }
+
+    @Test
+    fun `create a template with a prefix and a postfix`() {
+        Accessor.prefixAndPostfix("get", "Map").toString() shouldBe "get%sMap"
+    }
+
+    @Test
+    fun `provide equality based on the template`() {
+        EqualsTester()
+            .addEqualityGroup(Accessor.prefix("get"), Accessor.prefixAndPostfix("get", ""))
+            .addEqualityGroup(Accessor.prefix("set"))
+            .addEqualityGroup(Accessor.prefixAndPostfix("get", "Count"))
+            .testEquals()
     }
 }

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/field/FieldAccessorSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/field/FieldAccessorSpec.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.field
+
+import io.kotest.matchers.string.shouldContain
+import io.spine.base.EventMessageField
+import io.spine.tools.compiler.jvm.ClassName
+import io.spine.tools.compiler.protobuf.toField
+import io.spine.tools.core.jvm.field.given.farmField
+import io.spine.tools.core.jvm.field.given.farmTypeSystem
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("`FieldAccessor` should")
+internal class FieldAccessorSpec {
+
+    private val supertype = ClassName(EventMessageField::class.java)
+    private val typeSystem = farmTypeSystem()
+
+    private fun topLevel(fieldName: String) = TopLevelFieldAccessor(
+        field = farmField(fieldName).toField(),
+        fieldSupertype = supertype,
+        typeSystem = typeSystem
+    )
+
+    private fun nested(fieldName: String) = NestedFieldAccessor(
+        field = farmField(fieldName).toField(),
+        fieldSupertype = supertype,
+        typeSystem = typeSystem
+    )
+
+    @Nested inner class
+    `generate a top-level accessor` {
+
+        @Test
+        fun `for a simple field`() {
+            val method = topLevel("name").method()
+            val text = method.text
+            text shouldContain "public static"
+            text shouldContain supertype.canonical
+            text shouldContain "name()"
+            text shouldContain "io.spine.base.Field.named(\"name\")"
+            text shouldContain "Returns the {@code name} field."
+            text shouldContain "field Java type is {@code String}"
+        }
+
+        @Test
+        fun `for a message-typed field exposing nested fields`() {
+            val method = topLevel("barn").method()
+            val text = method.text
+            text shouldContain "BarnField barn()"
+            text shouldContain "new BarnField("
+        }
+
+        @Test
+        fun `for a repeated field`() {
+            val text = topLevel("tags").method().text
+            text shouldContain "Returns the {@code repeated} {@code tags} field."
+            text shouldContain "element Java type"
+        }
+
+        @Test
+        fun `for a map field`() {
+            val text = topLevel("names_by_id").method().text
+            text shouldContain "Returns the {@code map} {@code names_by_id} field."
+            text shouldContain "value Java type"
+        }
+    }
+
+    @Nested inner class
+    `generate a nested field accessor` {
+
+        @Test
+        fun `with an instance modifier and chained field path`() {
+            val method = nested("name").method()
+            val text = method.text
+            text shouldContain "public "
+            text shouldContain "getField().nested(\"name\")"
+        }
+    }
+}

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/field/FieldTypeSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/field/FieldTypeSpec.kt
@@ -24,35 +24,28 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+package io.spine.tools.core.jvm.field
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.spine.tools.core.jvm.field.given.farmDeclaration
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
+@DisplayName("`FieldType` should")
+internal class FieldTypeSpec {
+
+    @Test
+    fun `create a map field type for a map field`() {
+        FieldType.of(farmDeclaration("barns_by_name")).shouldBeInstanceOf<MapFieldType>()
+    }
+
+    @Test
+    fun `create a repeated field type for a repeated field`() {
+        FieldType.of(farmDeclaration("tags")).shouldBeInstanceOf<RepeatedFieldType>()
+    }
+
+    @Test
+    fun `create a singular field type for an ordinary field`() {
+        FieldType.of(farmDeclaration("name")).shouldBeInstanceOf<SingularFieldType>()
     }
 }

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/field/MapFieldTypeSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/field/MapFieldTypeSpec.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.field
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.shouldBe
+import io.spine.tools.core.jvm.field.given.farmDeclaration
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`MapFieldType` should")
+internal class MapFieldTypeSpec {
+
+    @Test
+    fun `box a primitive key type`() {
+        val type = MapFieldType(farmDeclaration("names_by_id"))
+        type.name().toString() shouldBe
+                "java.util.Map<java.lang.Integer, java.lang.String>"
+    }
+
+    @Test
+    fun `use declared types for non-primitive entries`() {
+        val type = MapFieldType(farmDeclaration("barns_by_name"))
+        type.name().toString() shouldBe
+                "java.util.Map<java.lang.String, io.spine.tools.core.jvm.given.base.Barn>"
+        type.toString() shouldBe type.name().toString()
+    }
+
+    @Test
+    fun `use 'putAll' as the primary setter`() {
+        val type = MapFieldType(farmDeclaration("names_by_id"))
+        type.primarySetter() shouldBe Accessor.prefix("putAll")
+    }
+
+    @Test
+    fun `enumerate map accessors`() {
+        val type = MapFieldType(farmDeclaration("names_by_id"))
+        type.accessors() shouldContainAll setOf(
+            Accessor.prefix("get"),
+            Accessor.prefixAndPostfix("get", "Map"),
+            Accessor.prefixAndPostfix("get", "OrDefault"),
+            Accessor.prefixAndPostfix("get", "OrThrow"),
+            Accessor.prefix("contains"),
+            Accessor.prefix("clear"),
+            Accessor.prefix("put"),
+            Accessor.prefix("remove"),
+            Accessor.prefix("putAll")
+        )
+    }
+
+    @Test
+    fun `reject a non-map field`() {
+        shouldThrow<IllegalArgumentException> {
+            MapFieldType(farmDeclaration("name"))
+        }
+    }
+}

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/field/MessageTypedFieldSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/field/MessageTypedFieldSpec.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.field
+
+import com.intellij.psi.PsiClass
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.spine.base.EventMessageField
+import io.spine.tools.compiler.jvm.ClassName
+import io.spine.tools.compiler.protobuf.toMessageType
+import io.spine.tools.core.jvm.field.given.farmTypeSystem
+import io.spine.tools.core.jvm.given.base.Barn
+import io.spine.tools.psi.java.execute
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`MessageTypedField` should")
+internal class MessageTypedFieldSpec {
+
+    private val supertype = ClassName(EventMessageField::class.java)
+    private val typeSystem = farmTypeSystem()
+
+    @Test
+    fun `generate a class for a message-typed field`() {
+        val type = Barn.getDescriptor().toMessageType()
+        lateinit var cls: PsiClass
+        execute {
+            cls = MessageTypedField(
+                fieldType = type,
+                fieldSupertype = supertype,
+                typeSystem = typeSystem
+            ).createClass()
+        }
+
+        cls.name shouldBe "BarnField"
+        cls.hasModifierProperty("public").shouldBeTrue()
+        cls.hasModifierProperty("static").shouldBeTrue()
+        cls.hasModifierProperty("final").shouldBeTrue()
+
+        val text = cls.text
+        text shouldContain supertype.canonical
+        text shouldContain "private BarnField(io.spine.base.Field field)"
+        text shouldContain "super(field);"
+        // Methods for the fields of `Barn`.
+        text shouldContain "title()"
+        text shouldContain "stall()"
+        // The Javadoc mentioning the message type.
+        text shouldContain "Provides fields of the {@link " +
+                "io.spine.tools.core.jvm.given.base.Barn} message type."
+    }
+
+    @Test
+    fun `compose a name for a nested message type`() {
+        val nested = Barn.Stall.getDescriptor().toMessageType()
+        MessageTypedField.classNameFor(nested) shouldBe "BarnStallField"
+    }
+}

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/field/PrimitiveTypeSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/field/PrimitiveTypeSpec.kt
@@ -24,35 +24,36 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+package io.spine.tools.core.jvm.field
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.optional.shouldBeEmpty
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
+@DisplayName("`PrimitiveType` should")
+internal class PrimitiveTypeSpec {
+
+    @Test
+    fun `provide wrappers for all supported primitives`() {
+        PrimitiveType.wrapperFor("int").shouldBePresent() shouldBe Int::class.javaObjectType
+        PrimitiveType.wrapperFor("long").shouldBePresent() shouldBe Long::class.javaObjectType
+        PrimitiveType.wrapperFor("float").shouldBePresent() shouldBe Float::class.javaObjectType
+        PrimitiveType.wrapperFor("double").shouldBePresent() shouldBe Double::class.javaObjectType
+        PrimitiveType.wrapperFor("boolean").shouldBePresent() shouldBe Boolean::class.javaObjectType
+    }
+
+    @Test
+    fun `return empty wrapper for a non-primitive name`() {
+        PrimitiveType.wrapperFor("String").shouldBeEmpty()
+    }
+
+    @Test
+    fun `reject an empty type name`() {
+        shouldThrow<IllegalArgumentException> {
+            PrimitiveType.wrapperFor("")
+        }
     }
 }

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/field/RepeatedFieldTypeSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/field/RepeatedFieldTypeSpec.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.field
+
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.spine.tools.core.jvm.field.given.farmDeclaration
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`RepeatedFieldType` should")
+internal class RepeatedFieldTypeSpec {
+
+    @Test
+    fun `box a primitive component type`() {
+        val type = RepeatedFieldType(farmDeclaration("counts"))
+        type.name().toString() shouldBe "java.util.List<java.lang.Integer>"
+    }
+
+    @Test
+    fun `use the declared component type for messages`() {
+        val type = RepeatedFieldType(farmDeclaration("barns"))
+        type.name().toString() shouldBe
+                "java.util.List<io.spine.tools.core.jvm.given.base.Barn>"
+        type.toString() shouldBe type.name().toString()
+    }
+
+    @Test
+    fun `use 'addAll' as the primary setter`() {
+        val type = RepeatedFieldType(farmDeclaration("tags"))
+        type.primarySetter() shouldBe Accessor.prefix("addAll")
+    }
+
+    @Test
+    fun `enumerate repeated field accessors`() {
+        val type = RepeatedFieldType(farmDeclaration("tags"))
+        type.accessors() shouldContainExactlyInAnyOrder setOf(
+            Accessor.prefix("get"),
+            Accessor.prefixAndPostfix("get", "List"),
+            Accessor.prefixAndPostfix("get", "Count"),
+            Accessor.prefix("set"),
+            Accessor.prefix("add"),
+            Accessor.prefix("addAll"),
+            Accessor.prefix("clear")
+        )
+    }
+}

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/field/RequiredIdReactionSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/field/RequiredIdReactionSpec.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.field
+
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.spine.core.External
+import io.spine.server.event.NoReaction
+import io.spine.server.event.React
+import io.spine.server.tuple.EitherOf2
+import io.spine.tools.compiler.ast.Field
+import io.spine.tools.compiler.ast.event.TypeDiscovered
+import io.spine.tools.compiler.protobuf.toField
+import io.spine.tools.core.jvm.field.given.farmField
+import io.spine.tools.validation.event.RequiredFieldDiscovered
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`RequiredIdReaction` should")
+internal class RequiredIdReactionSpec {
+
+    private val reaction = TestReaction()
+
+    @Test
+    fun `ignore a field with the explicit 'required' option`() {
+        val outcome = reaction.test(farmField("id").toField(), MESSAGE)
+        outcome.hasB().shouldBeTrue()
+    }
+
+    @Test
+    fun `ignore a field of an unsupported type`() {
+        val outcome = reaction.test(farmField("rating").toField(), MESSAGE)
+        outcome.hasB().shouldBeTrue()
+    }
+
+    @Test
+    fun `discover an implicitly required ID field`() {
+        val field = farmField("name").toField()
+        val outcome = reaction.test(field, MESSAGE)
+
+        outcome.hasA().shouldBeTrue()
+        val event = outcome.a
+        event.subject shouldBe field
+        event.defaultErrorMessage shouldBe MESSAGE
+    }
+
+    private companion object {
+        const val MESSAGE = "The ID field must be set."
+    }
+}
+
+/**
+ * Opens [RequiredIdReaction.withField] for direct calls in tests.
+ */
+private class TestReaction : RequiredIdReaction() {
+
+    @React
+    override fun whenever(
+        @External event: TypeDiscovered
+    ): EitherOf2<RequiredFieldDiscovered, NoReaction> = ignore()
+
+    fun test(field: Field, message: String): EitherOf2<RequiredFieldDiscovered, NoReaction> =
+        withField(field, message)
+}

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/field/SingularFieldTypeSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/field/SingularFieldTypeSpec.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.field
+
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.spine.tools.core.jvm.field.given.farmDeclaration
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`SingularFieldType` should")
+internal class SingularFieldTypeSpec {
+
+    @Test
+    fun `unbox a primitive type name`() {
+        SingularFieldType(farmDeclaration("size")).name().toString() shouldBe "int"
+    }
+
+    @Test
+    fun `convert a nested binary class name to the dot notation`() {
+        val type = SingularFieldType(farmDeclaration("stall"))
+        type.name().toString() shouldBe "io.spine.tools.core.jvm.given.base.Barn.Stall"
+    }
+
+    @Test
+    fun `expose extra accessors for string fields`() {
+        val accessors = SingularFieldType(farmDeclaration("name")).accessors()
+        accessors shouldContain Accessor.prefixAndPostfix("get", "Bytes")
+        accessors shouldContain Accessor.prefixAndPostfix("set", "Bytes")
+    }
+
+    @Test
+    fun `not expose string accessors for other types`() {
+        val accessors = SingularFieldType(farmDeclaration("size")).accessors()
+        accessors shouldNotContain Accessor.prefixAndPostfix("get", "Bytes")
+        accessors shouldContain Accessor.prefix("has")
+        accessors shouldContain Accessor.prefix("get")
+        accessors shouldContain Accessor.prefix("set")
+        accessors shouldContain Accessor.prefix("clear")
+    }
+
+    @Test
+    fun `use 'set' as the primary setter`() {
+        SingularFieldType(farmDeclaration("name")).primarySetter() shouldBe
+                Accessor.prefix("set")
+    }
+
+    @Test
+    fun `support enum fields`() {
+        val type = SingularFieldType(farmDeclaration("color"))
+        type.name().toString() shouldBe "io.spine.tools.core.jvm.given.base.Color"
+    }
+}

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/field/given/FarmFields.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/field/given/FarmFields.kt
@@ -24,35 +24,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+package io.spine.tools.core.jvm.field.given
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import com.google.protobuf.Descriptors.FieldDescriptor
+import io.spine.code.proto.FieldDeclaration
+import io.spine.tools.core.jvm.given.base.Farm
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
-    }
-}
+/**
+ * Obtains the descriptor of the [Farm] field with the given name.
+ */
+internal fun farmField(name: String): FieldDescriptor =
+    Farm.getDescriptor().findFieldByName(name)
+        ?: error("The field `$name` is not declared in `Farm`.")
+
+/**
+ * Obtains the declaration of the [Farm] field with the given name.
+ */
+internal fun farmDeclaration(name: String): FieldDeclaration =
+    FieldDeclaration(farmField(name))

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/field/given/FarmTypes.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/field/given/FarmTypes.kt
@@ -24,35 +24,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+package io.spine.tools.core.jvm.field.given
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import io.spine.tools.compiler.protobuf.ProtoFileList
+import io.spine.tools.compiler.protobuf.toPbSourceFile
+import io.spine.tools.compiler.type.TypeSystem
+import io.spine.tools.core.jvm.given.base.Farm
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
-    }
-}
+/**
+ * Creates a [TypeSystem] which knows only the types declared in `farm.proto`.
+ */
+internal fun farmTypeSystem(): TypeSystem =
+    TypeSystem(
+        ProtoFileList(emptyList()),
+        setOf(Farm.getDescriptor().file.toPbSourceFile())
+    )

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/CoreJvmCompilerTaskNameSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/CoreJvmCompilerTaskNameSpec.kt
@@ -24,28 +24,46 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.tools.core.jvm.annotation
+package io.spine.tools.core.jvm.gradle
 
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
-import io.spine.tools.core.annotation.ApiAnnotationsPlugin
+import io.spine.tools.code.SourceSetName
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
-@DisplayName("`ApiAnnotationsPlugin` should")
-internal class ApiAnnotationsPluginSpec {
+@DisplayName("`CoreJvmCompilerTaskName` should provide the name of")
+internal class CoreJvmCompilerTaskNameSpec {
+
+    private val test = SourceSetName.test
 
     @Test
-    fun `provide views and renderers`() {
-        val plugin = ApiAnnotationsPlugin()
-        plugin shouldNotBe null
-        plugin.views.size shouldNotBe 0
-        plugin.renderers.size shouldNotBe 0
+    fun `the 'preClean' task`() {
+        CoreJvmCompilerTaskName.preClean.name() shouldBe "preClean"
     }
 
     @Test
-    fun `expose the settings ID`() {
-        ApiAnnotationsPlugin.SETTINGS_ID shouldBe
-                "io.spine.tools.core.annotation.ApiAnnotationsPlugin"
+    fun `the descriptor set merging task`() {
+        CoreJvmCompilerTaskName.mergeDescriptorSet.name() shouldBe
+                "mergeDescriptorSet"
+        CoreJvmCompilerTaskName.mergeDescriptorSet(test).name() shouldBe
+                CoreJvmCompilerTaskName.mergeTestDescriptorSet.name()
+    }
+
+    @Test
+    fun `the plugin configuration task`() {
+        CoreJvmCompilerTaskName.writePluginConfiguration(test).name() shouldBe
+                "writeTestPluginConfiguration"
+    }
+
+    @Test
+    fun `the descriptor reference task`() {
+        CoreJvmCompilerTaskName.writeDescriptorReference(test).name() shouldBe
+                "writeTestDescriptorReferences"
+    }
+
+    @Test
+    fun `the compiler launch task`() {
+        CoreJvmCompilerTaskName.launchSpineCompiler.name() shouldBe
+                CoreJvmCompilerTaskName.launchSpineCompiler(SourceSetName.main).name()
     }
 }

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/CoreJvmOptionsSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/CoreJvmOptionsSpec.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.gradle
+
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.spine.annotation.Beta
+import io.spine.annotation.Experimental
+import io.spine.annotation.Internal
+import io.spine.annotation.SPI
+import io.spine.tools.compiler.jvm.style.javaCodeStyleDefaults
+import io.spine.tools.core.jvm.gradle.given.createCoreJvmOptions
+import io.spine.tools.core.jvm.gradle.given.newProject
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("`CoreJvmOptions` should")
+internal class CoreJvmOptionsSpec {
+
+    private lateinit var options: CoreJvmOptions
+
+    @BeforeEach
+    fun createOptions() {
+        val project = newProject()
+        options = project.createCoreJvmOptions()
+        options.injectProject(project)
+    }
+
+    @Test
+    fun `provide the extension name`() {
+        CoreJvmOptions.NAME shouldBe "coreJvm"
+        CoreJvmOptions.name() shouldBe CoreJvmOptions.NAME
+    }
+
+    @Test
+    fun `obtain default paths of a project`() {
+        val project = newProject()
+        CoreJvmOptions.def(project).path() shouldBe project.projectDir.toPath()
+    }
+
+    @Test
+    fun `use the default Java code style`() {
+        options.style.get() shouldBe javaCodeStyleDefaults()
+    }
+
+    @Test
+    fun `expose compiler settings after project injection`() {
+        options.compiler.shouldNotBeNull()
+        var configured = false
+        options.compiler {
+            configured = true
+        }
+        configured shouldBe true
+    }
+
+    @Nested inner class
+    `configure annotation settings` {
+
+        @Test
+        fun `using standard annotation types by default`() {
+            val types = options.annotation.types
+            types.experimental.get() shouldBe Experimental::class.java.canonicalName
+            types.beta.get() shouldBe Beta::class.java.canonicalName
+            types.spi.get() shouldBe SPI::class.java.canonicalName
+            types.internal.get() shouldBe Internal::class.java.canonicalName
+        }
+
+        @Test
+        fun `via the 'annotation' action`() {
+            options.annotation {
+                it.internalClassPatterns.set(listOf(".*Internal.*"))
+            }
+            options.annotation.internalClassPatterns.get() shouldBe listOf(".*Internal.*")
+        }
+
+        @Test
+        fun `via the 'generateAnnotations' action`() {
+            options.generateAnnotations {
+                it.internalMethodNames.set(listOf("getValue"))
+            }
+            options.annotation.internalMethodNames.get() shouldBe listOf("getValue")
+        }
+
+        @Test
+        fun `via the 'types' action`() {
+            options.annotation.types {
+                it.internal.set("custom.Internal")
+            }
+            options.annotation.types.internal.get() shouldBe "custom.Internal"
+        }
+    }
+}

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/LoggerExtsSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/LoggerExtsSpec.kt
@@ -24,35 +24,30 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+package io.spine.tools.core.jvm.gradle
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.matchers.shouldBe
+import org.gradle.api.logging.Logging
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
+@DisplayName("Extensions for Gradle `Logger` should")
+internal class LoggerExtsSpec {
+
+    private val logger = Logging.getLogger(LoggerExtsSpec::class.java)
+
+    @Test
+    fun `expose the logging prefix`() {
+        LOG_PREFIX shouldBe "[CoreJvm Compiler] "
+    }
+
+    @Test
+    fun `log messages of supported levels without failure`() {
+        shouldNotThrowAny {
+            logger.info { "info message" }
+            logger.warn { "warn message" }
+            logger.debug { "debug message" }
+        }
     }
 }

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/ProjectExtsSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/ProjectExtsSpec.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.gradle
+
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.spine.tools.code.SourceSetName
+import io.spine.tools.core.jvm.gradle.given.createCoreJvmOptions
+import io.spine.tools.core.jvm.gradle.given.newProject
+import io.spine.tools.fs.DirectoryName
+import io.spine.tools.gradle.project.sourceSet
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("Extensions for `Project` should")
+internal class ProjectExtsSpec {
+
+    @Test
+    fun `obtain CoreJvm options`() {
+        val project = newProject()
+        val options = project.createCoreJvmOptions()
+        project.coreJvmOptions shouldBe options
+    }
+
+    @Test
+    fun `obtain the proto directory of a source set`() {
+        val project = newProject()
+        val expected = project.projectDir.toPath()
+            .resolve("src")
+            .resolve("main")
+            .resolve("proto")
+        project.protoDir(SourceSetName.main) shouldBe expected
+    }
+
+    @Test
+    fun `return no proto files when a source set has no 'proto' extension`() {
+        val project = newProject()
+        project.pluginManager.apply("java")
+        project.protoFiles(SourceSetName.main).shouldBeNull()
+    }
+
+    @Test
+    fun `obtain proto files of a source set`() {
+        val project = newProject()
+        project.pluginManager.apply("java")
+        val files = project.files("foo.proto")
+        project.sourceSet(SourceSetName.main)
+            .extensions
+            .add("proto", files)
+        project.protoFiles(SourceSetName.main) shouldBe files
+    }
+
+    @Test
+    fun `name directories with generated code`() {
+        generatedJavaDirName shouldBe DirectoryName.java
+        generatedGrpcDirName shouldBe DirectoryName.grpc
+    }
+}

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/TempArtifactDirsSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/TempArtifactDirsSpec.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.gradle
+
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.string.shouldStartWith
+import io.spine.tools.core.jvm.gradle.given.createCoreJvmOptions
+import io.spine.tools.core.jvm.gradle.given.newProject
+import io.spine.tools.java.fs.DefaultJavaPaths
+import java.io.File
+import org.gradle.api.Project
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+@DisplayName("`TempArtifactDirs` should")
+internal class TempArtifactDirsSpec {
+
+    private fun dirsFor(project: Project): List<String> =
+        TempArtifactDirs.getFor(project).map(File::toString)
+
+    @Test
+    fun `return the default 'generated' directory when no options are set`(
+        @TempDir projectDir: File
+    ) {
+        val project = newProject(projectDir)
+        project.createCoreJvmOptions()
+
+        val dirs = dirsFor(project)
+
+        dirs shouldHaveSize 1
+        dirs[0] shouldStartWith project.projectDir.absolutePath
+    }
+
+    @Test
+    fun `return directories set via options`(@TempDir projectDir: File) {
+        val project = newProject(projectDir)
+        val options = project.createCoreJvmOptions()
+        options.tempArtifactDirs = listOf("foo-bar", "baz")
+
+        val dirs = dirsFor(project)
+
+        dirs shouldContain File("foo-bar").toString()
+        dirs shouldContain File("baz").toString()
+    }
+
+    @Test
+    fun `include the temp artifacts directory when it exists`(@TempDir projectDir: File) {
+        val project = newProject(projectDir)
+        project.createCoreJvmOptions()
+        val tempArtifacts = DefaultJavaPaths.at(projectDir).tempArtifacts()
+        check(tempArtifacts.mkdirs())
+
+        val dirs = dirsFor(project)
+
+        dirs shouldContain tempArtifacts.canonicalPath
+    }
+
+    @Test
+    fun `include the temp artifacts directory of the root project`(
+        @TempDir rootDir: File,
+        @TempDir childDir: File
+    ) {
+        val root = newProject(rootDir)
+        val child = newProject(childDir, parent = root)
+        child.createCoreJvmOptions()
+        val childTempArtifacts = DefaultJavaPaths.at(childDir).tempArtifacts()
+        val rootTempArtifacts = DefaultJavaPaths.at(rootDir).tempArtifacts()
+        check(childTempArtifacts.mkdirs())
+        check(rootTempArtifacts.mkdirs())
+
+        val dirs = dirsFor(child)
+
+        dirs shouldContain childTempArtifacts.canonicalPath
+        dirs shouldContain rootTempArtifacts.canonicalPath
+    }
+}

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/given/TestProjects.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/given/TestProjects.kt
@@ -24,35 +24,30 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+package io.spine.tools.core.jvm.gradle.given
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import io.spine.tools.core.jvm.gradle.CoreJvmOptions
+import io.spine.tools.gradle.root.RootPlugin
+import io.spine.tools.gradle.root.rootExtension
+import java.io.File
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
-    }
+/**
+ * Creates a Gradle project in the given directory.
+ */
+internal fun newProject(dir: File? = null, parent: Project? = null): Project {
+    val builder = ProjectBuilder.builder()
+    dir?.let { builder.withProjectDir(it) }
+    parent?.let { builder.withParent(it) }
+    return builder.build()
+}
+
+/**
+ * Registers the `coreJvm` extension in this project the way
+ * the CoreJvm Gradle plugin does it.
+ */
+internal fun Project.createCoreJvmOptions(): CoreJvmOptions {
+    pluginManager.apply(RootPlugin::class.java)
+    return rootExtension.extensions.create(CoreJvmOptions.NAME, CoreJvmOptions::class.java)
 }

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/module/ModuleOptionsSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/module/ModuleOptionsSpec.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.gradle.module
+
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.spine.tools.core.jvm.gradle.CoreJvm
+import io.spine.tools.core.jvm.gradle.CoreJvmOptions
+import io.spine.tools.core.jvm.gradle.given.createCoreJvmOptions
+import io.spine.tools.core.jvm.gradle.given.newProject
+import org.gradle.api.Project
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.api.internal.project.ProjectInternal
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`ModuleOptions` should")
+internal class ModuleOptionsSpec {
+
+    private lateinit var project: Project
+    private lateinit var options: CoreJvmOptions
+
+    @BeforeEach
+    fun createOptions() {
+        project = newProject()
+        // The `implementation` configuration must exist when `ModuleOptions`
+        // adds the dependency on project evaluation.
+        project.pluginManager.apply("java")
+        options = project.createCoreJvmOptions()
+    }
+
+    @Test
+    fun `use the 'SERVER' module kind by default`() {
+        options.module.kind.get() shouldBe ModuleKind.SERVER
+    }
+
+    @Test
+    fun `add Spine artifact repositories`() {
+        options.module.shouldNotBeNull()
+        val urls = project.repositories
+            .filterIsInstance<MavenArtifactRepository>()
+            .map { it.url.toString() }
+        urls shouldContain ArtifactRegistry.releases
+        urls shouldContain ArtifactRegistry.snapshots
+    }
+
+    @Test
+    fun `allow changing the module kind`() {
+        options.module.kind.set(ModuleKind.CLIENT)
+        options.module.kind.get() shouldBe ModuleKind.CLIENT
+    }
+
+    @Test
+    fun `add the 'spine-server' dependency for the 'SERVER' module kind`() {
+        options.module.shouldNotBeNull()
+        (project as ProjectInternal).evaluate()
+        implementationDependencies() shouldContain CoreJvm.server.artifact.coordinates
+    }
+
+    @Test
+    fun `add the 'spine-client' dependency for the 'CLIENT' module kind`() {
+        options.module.kind.set(ModuleKind.CLIENT)
+        (project as ProjectInternal).evaluate()
+        implementationDependencies() shouldContain CoreJvm.client.artifact.coordinates
+    }
+
+    /**
+     * Obtains Maven coordinates of the dependencies added to
+     * the `implementation` configuration of the [project].
+     */
+    private fun implementationDependencies(): List<String> =
+        project.configurations
+            .getByName("implementation")
+            .dependencies
+            .map { "${it.group}:${it.name}:${it.version}" }
+}

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/settings/ComparableSettingsSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/settings/ComparableSettingsSpec.kt
@@ -24,35 +24,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+package io.spine.tools.core.jvm.gradle.settings
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import io.kotest.matchers.maps.shouldContainKey
+import io.spine.tools.core.jvm.gradle.given.newProject
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
+@DisplayName("`ComparableSettings` should")
+internal class ComparableSettingsSpec {
+
+    @Test
+    fun `apply default actions`() {
+        val settings = ComparableSettings(newProject())
+        val actions = settings.toProto().actions.actionMap
+
+        actions shouldContainKey "io.spine.tools.core.jvm.comparable.action.AddComparator"
+        actions shouldContainKey "io.spine.tools.core.jvm.comparable.action.AddCompareTo"
+        actions shouldContainKey
+                "io.spine.tools.core.jvm.comparable.action.ImplementComparable"
     }
 }

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/settings/CoreJvmCompilerSettingsSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/settings/CoreJvmCompilerSettingsSpec.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.gradle.settings
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.maps.shouldContainKey
+import io.kotest.matchers.shouldBe
+import io.spine.tools.compiler.ast.FilePatternFactory
+import io.spine.tools.core.jvm.gradle.given.newProject
+import org.gradle.api.Project
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("`CoreJvmCompilerSettings` should")
+internal class CoreJvmCompilerSettingsSpec {
+
+    private lateinit var project: Project
+    private lateinit var settings: CoreJvmCompilerSettings
+
+    @BeforeEach
+    fun createSettings() {
+        project = newProject()
+        project.pluginManager.apply("java")
+        settings = CoreJvmCompilerSettings(project)
+    }
+
+    @Test
+    fun `be enabled by default`() {
+        settings.enabled.get().shouldBeTrue()
+    }
+
+    @Test
+    fun `expose a file pattern factory`() {
+        settings.by() shouldBe FilePatternFactory
+    }
+
+    @Nested inner class
+    `configure code generation` {
+
+        @Test
+        fun `for commands`() {
+            settings.forCommands {
+                it.includeFiles(settings.by().suffix("custom_commands.proto"))
+                it.includeFiles(settings.by().regex(".*cmd.*"))
+            }
+            settings.commands.patterns() shouldHaveSize 2
+        }
+
+        @Test
+        fun `for events`() {
+            var configured = false
+            settings.forEvents { configured = true }
+            configured.shouldBeTrue()
+        }
+
+        @Test
+        fun `for rejections`() {
+            var configured = false
+            settings.forRejections { configured = true }
+            configured.shouldBeTrue()
+        }
+
+        @Test
+        fun `for entities`() {
+            var configured = false
+            settings.forEntities { configured = true }
+            configured.shouldBeTrue()
+        }
+
+        @Test
+        fun `for UUID values`() {
+            var configured = false
+            settings.forUuids { configured = true }
+            configured.shouldBeTrue()
+        }
+
+        @Test
+        fun `for comparable messages`() {
+            var configured = false
+            settings.forComparables { configured = true }
+            configured.shouldBeTrue()
+        }
+
+        @Test
+        fun `for messages selected by a file pattern`() {
+            settings.forMessages(settings.by().suffix("ids.proto")) {
+                it.useAction(ACTION)
+            }
+            settings.messageGroups shouldHaveSize 1
+        }
+
+        @Test
+        fun `for a message selected by its type name`() {
+            settings.forMessage(FARM_TYPE) {
+                it.useAction(ACTION)
+            }
+            settings.messageGroups shouldHaveSize 1
+        }
+
+        @Test
+        fun `rejecting a message group without actions`() {
+            shouldThrow<IllegalStateException> {
+                settings.forMessages(settings.by().suffix("ids.proto")) {
+                    // No actions are configured.
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `convert itself to Protobuf`() {
+        settings.forMessage(FARM_TYPE) {
+            it.useAction(ACTION)
+        }
+        val proto = settings.toProto()
+
+        proto.hasSignalSettings().shouldBeTrue()
+        proto.signalSettings.hasCommands().shouldBeTrue()
+        proto.signalSettings.hasEvents().shouldBeTrue()
+        proto.signalSettings.hasRejections().shouldBeTrue()
+        proto.hasEntities().shouldBeTrue()
+        proto.hasUuids().shouldBeTrue()
+        proto.hasComparables().shouldBeTrue()
+        proto.groupSettings.groupList shouldHaveSize 1
+        proto.entities.actions.actionMap shouldContainKey
+                "io.spine.tools.core.jvm.entity.ImplementEntityState"
+    }
+
+    private companion object {
+        const val ACTION = "custom.Action"
+        const val FARM_TYPE = "given.base.Farm"
+    }
+}

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/settings/EntitySettingsSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/settings/EntitySettingsSpec.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.gradle.settings
+
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.maps.shouldContainKey
+import io.spine.tools.core.jvm.gradle.given.newProject
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`EntitySettings` should")
+internal class EntitySettingsSpec {
+
+    private lateinit var settings: EntitySettings
+
+    @BeforeEach
+    fun createSettings() {
+        settings = EntitySettings(newProject())
+    }
+
+    @Test
+    fun `use the 'entity' option by default`() {
+        settings.options.get() shouldContain "entity"
+    }
+
+    @Test
+    fun `generate queries by default`() {
+        settings.toProto().generateQueries.shouldBeTrue()
+    }
+
+    @Test
+    fun `allow skipping query generation`() {
+        settings.skipQueries()
+        settings.toProto().generateQueries.shouldBeFalse()
+    }
+
+    @Test
+    fun `allow re-enabling query generation`() {
+        settings.skipQueries()
+        settings.generateQueries()
+        settings.toProto().generateQueries.shouldBeTrue()
+    }
+
+    @Test
+    fun `convert itself to Protobuf`() {
+        val proto = settings.toProto()
+        proto.optionList.map { it.name } shouldContain "entity"
+        proto.actions.actionMap shouldContainKey
+                "io.spine.tools.core.jvm.entity.ImplementEntityState"
+    }
+}

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/settings/MessageGroupSettingsSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/settings/MessageGroupSettingsSpec.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.gradle.settings
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.maps.shouldContainKey
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.spine.tools.core.jvm.field.AddFieldClass
+import io.spine.tools.core.jvm.gradle.given.newProject
+import io.spine.tools.core.jvm.settings.pattern
+import io.spine.tools.core.jvm.settings.typePattern
+import io.spine.tools.proto.code.protoTypeName
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`MessageGroupSettings` should")
+internal class MessageGroupSettingsSpec {
+
+    private lateinit var settings: MessageGroupSettings
+
+    private val pattern = pattern {
+        type = typePattern {
+            expectedType = protoTypeName { value = FARM_TYPE }
+        }
+    }
+
+    @BeforeEach
+    fun createSettings() {
+        settings = MessageGroupSettings(newProject(), pattern)
+    }
+
+    @Test
+    fun `require at least one action`() {
+        shouldThrow<IllegalStateException> {
+            settings.toProto()
+        }
+    }
+
+    @Test
+    fun `mark fields with a custom class`() {
+        settings.markFieldsAs("custom.FieldSupertype")
+        settings.actions().actionMap shouldContainKey AddFieldClass::class.java.name
+    }
+
+    @Test
+    fun `convert itself to Protobuf`() {
+        settings.useAction(ACTION)
+        val proto = settings.toProto()
+        proto.pattern shouldBe pattern
+        proto.actions.actionMap shouldContainKey ACTION
+    }
+
+    @Test
+    fun `describe itself with the pattern`() {
+        settings.toString() shouldContain FARM_TYPE
+    }
+
+    private companion object {
+        const val ACTION = "custom.Action"
+        const val FARM_TYPE = "given.base.Farm"
+    }
+}

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/settings/SettingsWithActionsSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/settings/SettingsWithActionsSpec.kt
@@ -44,7 +44,7 @@ internal class SettingsWithActionsSpec {
     private lateinit var settings: UuidSettings
 
     /**
-     * The name of the interface action as used by [markAs] methods.
+     * The name of the interface action as used by [SettingsWithActions.markAs] methods.
      */
     private val implementInterface = ImplementInterface::class.java.name
 

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/settings/SettingsWithActionsSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/settings/SettingsWithActionsSpec.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.gradle.settings
+
+import com.google.protobuf.StringValue
+import com.google.protobuf.stringValue
+import io.kotest.matchers.maps.shouldContainKey
+import io.kotest.matchers.shouldBe
+import io.spine.tools.compiler.jvm.render.ImplementInterface
+import io.spine.tools.compiler.jvm.render.SuperInterface
+import io.spine.tools.core.jvm.gradle.given.newProject
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("`SettingsWithActions` should")
+internal class SettingsWithActionsSpec {
+
+    private lateinit var settings: UuidSettings
+
+    /**
+     * The name of the interface action as used by [markAs] methods.
+     */
+    private val implementInterface = ImplementInterface::class.java.name
+
+    @BeforeEach
+    fun createSettings() {
+        settings = UuidSettings(newProject())
+    }
+
+    private fun action(className: String) =
+        settings.actions().actionMap.getValue(className)
+
+    private companion object {
+        const val ACTION = "custom.Action"
+    }
+
+    @Test
+    fun `mark messages with an interface`() {
+        settings.markAs("custom.Interface")
+        val parameter = action(implementInterface).unpack(SuperInterface::class.java)
+        parameter.name shouldBe "custom.Interface"
+    }
+
+    @Test
+    fun `mark messages with a generic interface`() {
+        settings.markAs("custom.Generic", listOf("A", "B"))
+        val parameter = action(implementInterface).unpack(SuperInterface::class.java)
+        parameter.name shouldBe "custom.Generic"
+        parameter.genericArgumentList shouldBe listOf("A", "B")
+    }
+
+    @Nested inner class
+    `apply custom actions` {
+
+        @Test
+        fun `without a parameter`() {
+            settings.useAction(ACTION)
+            settings.actions().actionMap shouldContainKey ACTION
+        }
+
+        @Test
+        fun `with a message parameter`() {
+            val parameter = stringValue { value = "param" }
+            settings.useAction(ACTION, parameter)
+            action(ACTION).unpack(StringValue::class.java) shouldBe parameter
+        }
+
+        @Test
+        fun `with a string parameter`() {
+            settings.useAction(ACTION, "param")
+            action(ACTION).unpack(StringValue::class.java).value shouldBe "param"
+        }
+
+        @Test
+        fun `passed as a collection`() {
+            settings.useActions(listOf("custom.One", "custom.Two"))
+            val map = settings.actions().actionMap
+            map shouldContainKey "custom.One"
+            map shouldContainKey "custom.Two"
+        }
+
+        @Test
+        fun `passed as a vararg`() {
+            settings.useActions("custom.One", "custom.Two")
+            val map = settings.actions().actionMap
+            map shouldContainKey "custom.One"
+            map shouldContainKey "custom.Two"
+        }
+    }
+}

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/settings/SignalSettingsSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/settings/SignalSettingsSpec.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.gradle.settings
+
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.maps.shouldContainKey
+import io.kotest.matchers.shouldBe
+import io.spine.base.CommandMessage
+import io.spine.base.EventMessage
+import io.spine.base.MessageFile
+import io.spine.base.RejectionMessage
+import io.spine.tools.compiler.ast.FilePattern
+import io.spine.tools.compiler.ast.FilePatternFactory
+import io.spine.tools.compiler.jvm.render.ImplementInterface
+import io.spine.tools.compiler.jvm.render.SuperInterface
+import io.spine.tools.core.jvm.gradle.given.newProject
+import io.spine.tools.java.reference
+import org.gradle.api.Project
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("`SignalSettings` should")
+internal class SignalSettingsSpec {
+
+    private lateinit var project: Project
+    private lateinit var settings: CoreJvmCompilerSettings
+
+    @BeforeEach
+    fun createSettings() {
+        project = newProject()
+        settings = CoreJvmCompilerSettings(project)
+    }
+
+    private fun interfaceOf(signals: SignalSettings): String {
+        val packed = signals.actions().actionMap.getValue(ImplementInterface::class.java.name)
+        return packed.unpack(SuperInterface::class.java).name
+    }
+
+    @Nested inner class
+    `use conventional defaults` {
+
+        @Test
+        fun `for commands`() {
+            settings.commands.patterns() shouldBe
+                    setOf(suffix(MessageFile.COMMANDS))
+            interfaceOf(settings.commands) shouldBe CommandMessage::class.java.reference
+        }
+
+        @Test
+        fun `for events`() {
+            settings.events.patterns() shouldBe
+                    setOf(suffix(MessageFile.EVENTS))
+            interfaceOf(settings.events) shouldBe EventMessage::class.java.reference
+        }
+
+        @Test
+        fun `for rejections`() {
+            settings.rejections.patterns() shouldBe
+                    setOf(suffix(MessageFile.REJECTIONS))
+            interfaceOf(settings.rejections) shouldBe RejectionMessage::class.java.reference
+        }
+
+        private fun suffix(file: MessageFile): FilePattern =
+            FilePatternFactory.suffix(file.suffix())
+    }
+
+    @Test
+    fun `extend the group with more file patterns`() {
+        settings.commands.includeFiles(FilePatternFactory.regex(".*my_commands.*"))
+        settings.commands.includeFiles(FilePatternFactory.suffix("my_commands.proto"))
+        settings.commands.patterns() shouldHaveSize 2
+    }
+
+    @Test
+    fun `drop the default pattern when the convention is a default instance`() {
+        val signals = SignalSettings(
+            project = project,
+            suffix = "whatever.proto",
+            defaultActions = mapOf()
+        )
+        signals.convention(FilePattern.getDefaultInstance())
+        signals.patterns().shouldBeEmpty()
+    }
+
+    @Test
+    fun `convert itself to Protobuf`() {
+        val proto = settings.events.toProto()
+        proto.patternList shouldHaveSize 1
+        proto.actions.actionMap shouldContainKey ImplementInterface::class.java.name
+    }
+}

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/settings/UuidSettingsSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/gradle/settings/UuidSettingsSpec.kt
@@ -24,35 +24,26 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+package io.spine.tools.core.jvm.gradle.settings
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.maps.shouldContainKey
+import io.spine.tools.compiler.jvm.render.ImplementInterface
+import io.spine.tools.core.jvm.gradle.given.newProject
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
+@DisplayName("`UuidSettings` should")
+internal class UuidSettingsSpec {
+
+    @Test
+    fun `apply default actions`() {
+        val settings = UuidSettings(newProject())
+        settings.enabled.get().shouldBeTrue()
+
+        val proto = settings.toProto()
+        val actions = proto.actions.actionMap
+        actions shouldContainKey ImplementInterface::class.java.name
+        actions shouldContainKey "io.spine.tools.core.jvm.uuid.AddFactoryMethods"
     }
 }

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/settings/ActionsExtsSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/settings/ActionsExtsSpec.kt
@@ -24,35 +24,38 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "core-jvm-compiler"
+package io.spine.tools.core.jvm.settings
 
-include(
-    "plugins",
-    "annotation",
-    "annotation-tests",
-    "base",
-    "comparable",
-    "comparable-tests",
-    "entity",
-    "entity-tests",
-    "grpc",
-    "signal",
-    "signal-tests",
-    "ksp",
-    "marker",
-    "marker-tests",
-    "message-group",
-    "message-group-tests",
-    "routing",
-    "routing-tests",
-    "uuid",
-    "uuid-tests",
-)
+import com.google.protobuf.Any
+import com.google.protobuf.StringValue
+import com.google.protobuf.stringValue
+import io.kotest.matchers.shouldBe
+import io.spine.protobuf.pack
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        mavenCentral()
+@DisplayName("Extensions for `ActionMap` should")
+internal class ActionsExtsSpec {
+
+    @Test
+    fun `provide the default 'Any' as the no-parameter marker`() {
+        noParameter shouldBe Any.getDefaultInstance()
+    }
+
+    @Test
+    fun `keep values which are already packed`() {
+        val packed = stringValue { value = "already packed" }.pack()
+        val map: ActionMap = mapOf("custom.Action" to packed)
+
+        map.pack() shouldBe mapOf("custom.Action" to packed)
+    }
+
+    @Test
+    fun `pack message values`() {
+        val raw = stringValue { value = "raw" }
+        val map: ActionMap = mapOf("custom.Action" to raw)
+
+        val packed = map.pack()
+        packed.getValue("custom.Action").unpack(StringValue::class.java) shouldBe raw
     }
 }

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/settings/PatternsSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/settings/PatternsSpec.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.core.jvm.settings
+
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.spine.tools.compiler.ast.FilePatternFactory
+import io.spine.tools.compiler.protobuf.toMessageType
+import io.spine.tools.core.jvm.given.base.Farm
+import io.spine.tools.proto.code.protoTypeName
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("`Patterns` should")
+internal class PatternsSpec {
+
+    private val farm = Farm.getDescriptor().toMessageType()
+    private val farmName = "given.base.Farm"
+
+    @Nested inner class
+    `match a pattern by` {
+
+        @Test
+        fun `the file of the type`() {
+            val matching = pattern {
+                file = FilePatternFactory.suffix("farm.proto")
+            }
+            val nonMatching = pattern {
+                file = FilePatternFactory.suffix("barn.proto")
+            }
+            matching.matches(farm).shouldBeTrue()
+            nonMatching.matches(farm).shouldBeFalse()
+        }
+
+        @Test
+        fun `the type pattern`() {
+            val matching = pattern {
+                type = typePattern {
+                    expectedType = protoTypeName { value = farmName }
+                }
+            }
+            matching.matches(farm).shouldBeTrue()
+        }
+
+        @Test
+        fun `nothing when the kind is not set`() {
+            Pattern.getDefaultInstance().matches(farm).shouldBeFalse()
+        }
+    }
+
+    @Nested inner class
+    `match a type pattern by` {
+
+        @Test
+        fun `the expected type name`() {
+            val matching = typePattern {
+                expectedType = protoTypeName { value = farmName }
+            }
+            val nonMatching = typePattern {
+                expectedType = protoTypeName { value = "given.base.Unknown" }
+            }
+            matching.matches(farm).shouldBeTrue()
+            nonMatching.matches(farm).shouldBeFalse()
+        }
+
+        @Test
+        fun `a regular expression`() {
+            val matching = typePattern { regex = ".*base\\.F.*" }
+            val nonMatching = typePattern { regex = ".*base\\.B.*" }
+            matching.matches(farm).shouldBeTrue()
+            nonMatching.matches(farm).shouldBeFalse()
+        }
+
+        @Test
+        fun `nothing when the value is not set`() {
+            TypePattern.getDefaultInstance().matches(farm).shouldBeFalse()
+        }
+    }
+}

--- a/base/src/test/proto/given/base/farm.proto
+++ b/base/src/test/proto/given/base/farm.proto
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+syntax = "proto3";
+
+package given.base;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.tools.core.jvm.given.base";
+option java_outer_classname = "FarmProto";
+option java_multiple_files = true;
+
+import "google/protobuf/timestamp.proto";
+
+// A message with fields of various shapes used in tests of the `field` package
+// and field-path resolution.
+message Farm {
+
+    // The ID field marked as `(required)` explicitly.
+    string id = 1 [(required) = true];
+
+    // A singular `string` field.
+    string name = 2;
+
+    // A singular primitive field.
+    int32 size = 3;
+
+    // A singular `bool` field.
+    bool active = 4;
+
+    // A singular `bytes` field.
+    bytes data = 5;
+
+    // A singular `double` field.
+    double rating = 6;
+
+    // A singular message-typed field.
+    Barn barn = 7;
+
+    // A field of a nested message type.
+    Barn.Stall stall = 8;
+
+    // A repeated `string` field.
+    repeated string tags = 9;
+
+    // A repeated primitive field.
+    repeated int32 counts = 10;
+
+    // A repeated message-typed field.
+    repeated Barn barns = 11;
+
+    // A map with a message value type.
+    map<string, Barn> barns_by_name = 12;
+
+    // A map with a primitive key type.
+    map<int32, string> names_by_id = 13;
+
+    // A field of a type declared in another proto file.
+    google.protobuf.Timestamp built = 14;
+
+    // An enum field.
+    Color color = 15;
+}
+
+// A message nested structure used for testing nested field resolution.
+message Barn {
+
+    // A singular `string` field.
+    string title = 1;
+
+    // A field of the type nested into this message.
+    Stall stall = 2;
+
+    // A nested message type.
+    message Stall {
+
+        // A singular `string` field.
+        string id = 1;
+    }
+}
+
+// An enumeration for testing enum-typed fields.
+enum Color {
+
+    // The default value.
+    COLOR_UNDEFINED = 0;
+
+    // The red color.
+    RED = 1;
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@
 import io.spine.dependency.build.Dokka
 import io.spine.dependency.local.Compiler
 import io.spine.dependency.local.CoreJvm
+import io.spine.dependency.local.ProtoTap
 import io.spine.dependency.local.Spine
 import io.spine.dependency.local.Validation
 import io.spine.gradle.RunBuild
@@ -135,6 +136,20 @@ allprojects {
     group = Spine.toolsGroup
     version = extra["versionToPublish"]!!
     repositories.standardToSpineSdk()
+}
+
+subprojects {
+    pluginManager.withPlugin(ProtoTap.gradlePluginId) {
+        tasks.withType<com.google.protobuf.gradle.GenerateProtoTask>().configureEach {
+            outputs.cacheIf(
+                "ProtoTap stores `CodeGeneratorRequest.binpb` and the generated code" +
+                        " in test resources as a side effect without declaring them as" +
+                        " task outputs. A build-cache hit restores only the declared" +
+                        " outputs, so `PipelineSetup`-based suites fail to find" +
+                        " the capture. Always execute the task in tapped modules."
+            ) { false }
+        }
+    }
 }
 
 KoverConfig.applyTo(rootProject)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -150,17 +150,6 @@ subprojects {
                     " `PipelineSetup`-based test suites. Always run protoc."
         ) { false }
     }
-    tasks.configureEach {
-        if (name.startsWith("launch") && name.endsWith("SpineCompiler")) {
-            outputs.cacheIf(
-                "The Spine Compiler launch exchanges request and descriptor" +
-                        " files with other tasks outside the declared task" +
-                        " outputs. A build-cache hit restores only the generated" +
-                        " sources, leaving the module without the descriptor" +
-                        " resources required by `KnownTypes` at test runtime."
-            ) { false }
-        }
-    }
 }
 
 KoverConfig.applyTo(rootProject)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -139,14 +139,25 @@ allprojects {
 }
 
 subprojects {
-    pluginManager.withPlugin(ProtoTap.gradlePluginId) {
-        tasks.withType<com.google.protobuf.gradle.GenerateProtoTask>().configureEach {
+    tasks.withType<com.google.protobuf.gradle.GenerateProtoTask>().configureEach {
+        outputs.cacheIf(
+            "Protoc plugins used in this repository — ProtoTap in `*-tests`" +
+                    " modules and the Spine Compiler protoc plugin elsewhere —" +
+                    " write captures (`CodeGeneratorRequest.binpb`, descriptor" +
+                    " references) as side effects without declaring them as task" +
+                    " outputs. A build-cache hit restores only the declared" +
+                    " outputs, breaking the downstream codegen and" +
+                    " `PipelineSetup`-based test suites. Always run protoc."
+        ) { false }
+    }
+    tasks.configureEach {
+        if (name.startsWith("launch") && name.endsWith("SpineCompiler")) {
             outputs.cacheIf(
-                "ProtoTap stores `CodeGeneratorRequest.binpb` and the generated code" +
-                        " in test resources as a side effect without declaring them as" +
-                        " task outputs. A build-cache hit restores only the declared" +
-                        " outputs, so `PipelineSetup`-based suites fail to find" +
-                        " the capture. Always execute the task in tapped modules."
+                "The Spine Compiler launch exchanges request and descriptor" +
+                        " files with other tasks outside the declared task" +
+                        " outputs. A build-cache hit restores only the generated" +
+                        " sources, leaving the module without the descriptor" +
+                        " resources required by `KnownTypes` at test runtime."
             ) { false }
         }
     }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
@@ -72,7 +72,7 @@ object Compiler : Dependency() {
      * The version of the Compiler dependencies.
      */
     override val version: String
-    private const val fallbackVersion = "2.0.0-SNAPSHOT.051"
+    private const val fallbackVersion = "2.0.0-SNAPSHOT.052"
 
     /**
      * The distinct version of the Compiler used by other build tools.
@@ -81,7 +81,7 @@ object Compiler : Dependency() {
      * transitive dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.051"
+    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.052"
 
     /**
      * The artifact for the Compiler Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
@@ -46,12 +46,12 @@ object CoreJvmCompiler {
     /**
      * The version used in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.069"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.070"
 
     /**
      * The version to be used for integration tests.
      */
-    const val version = "2.0.0-SNAPSHOT.069"
+    const val version = "2.0.0-SNAPSHOT.070"
 
     /**
      * The ID of the Gradle plugin.

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -345,11 +345,7 @@
      * **Project URL:** [https://github.com/google/gson](https://github.com/google/gson)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.6.
-     * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.devtools.ksp. **Name** : symbol-processing. **Version** : 2.3.9.
+1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.9.
      * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1162,7 +1158,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
+This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2144,7 +2140,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
+This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2496,11 +2492,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
      * **Project URL:** [https://github.com/google/gson](https://github.com/google/gson)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.6.
-     * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.devtools.ksp. **Name** : symbol-processing. **Version** : 2.3.9.
+1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.9.
      * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3321,7 +3313,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
+This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3673,11 +3665,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
      * **Project URL:** [https://github.com/google/gson](https://github.com/google/gson)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.6.
-     * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.devtools.ksp. **Name** : symbol-processing. **Version** : 2.3.9.
+1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.9.
      * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -4490,7 +4478,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
+This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5472,7 +5460,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
+This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5824,11 +5812,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
      * **Project URL:** [https://github.com/google/gson](https://github.com/google/gson)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.6.
-     * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.devtools.ksp. **Name** : symbol-processing. **Version** : 2.3.9.
+1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.9.
      * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -6641,7 +6625,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
+This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -7623,7 +7607,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
+This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -8763,7 +8747,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
+This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -9979,7 +9963,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
+This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -10331,11 +10315,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
      * **Project URL:** [https://github.com/google/gson](https://github.com/google/gson)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.6.
-     * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.devtools.ksp. **Name** : symbol-processing. **Version** : 2.3.9.
+1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.9.
      * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -11156,7 +11136,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
+This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -12138,7 +12118,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
+This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -12490,11 +12470,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
      * **Project URL:** [https://github.com/google/gson](https://github.com/google/gson)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.6.
-     * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.devtools.ksp. **Name** : symbol-processing. **Version** : 2.3.9.
+1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.9.
      * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -13315,7 +13291,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
+This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -14297,7 +14273,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
+This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -15529,7 +15505,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
+This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -15913,7 +15889,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
      * **Project URL:** [https://github.com/google/gson](https://github.com/google/gson)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.6.
+1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.9.
      * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -16778,7 +16754,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
+This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -16857,11 +16833,6 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-bom](https://github.com/FasterXML/jackson-bom)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
      * **Project URL:** [https://github.com/FasterXML/jackson-bom](https://github.com/FasterXML/jackson-bom)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -16871,20 +16842,11 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
      * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.21.
-     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.22.
      * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.21.3.
      * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -16899,11 +16861,6 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.21.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.22.0.
      * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -16914,18 +16871,8 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-yaml. **Version** : 2.21.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-dataformats-text](https://github.com/FasterXML/jackson-dataformats-text)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-yaml. **Version** : 2.22.0.
      * **Project URL:** [https://github.com/FasterXML/jackson-dataformats-text](https://github.com/FasterXML/jackson-dataformats-text)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.datatype. **Name** : jackson-datatype-guava. **Version** : 2.21.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-datatypes-collections](https://github.com/FasterXML/jackson-datatypes-collections)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -16934,18 +16881,8 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.datatype. **Name** : jackson-datatype-jdk8. **Version** : 2.21.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8](https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : com.fasterxml.jackson.datatype. **Name** : jackson-datatype-jdk8. **Version** : 2.22.0.
      * **Project URL:** [https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8](https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.datatype. **Name** : jackson-datatype-jsr310. **Version** : 2.21.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310](https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -16959,20 +16896,10 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.21.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.22.0.
      * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-parameter-names. **Version** : 2.21.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names](https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-parameter-names. **Version** : 2.22.0.
      * **Project URL:** [https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names](https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names)
@@ -16983,10 +16910,6 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
      * **Project URL:** [https://github.com/FasterXML/woodstox](https://github.com/FasterXML/woodstox)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.1.8.
-     * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.2.4.
      * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
@@ -17020,11 +16943,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
      * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.6.
-     * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.devtools.ksp. **Name** : symbol-processing. **Version** : 2.3.6.
+1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.9.
      * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -17032,23 +16951,11 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
      * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.devtools.ksp. **Name** : symbol-processing-api. **Version** : 2.3.6.
-     * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : com.google.devtools.ksp. **Name** : symbol-processing-api. **Version** : 2.3.9.
      * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.devtools.ksp. **Name** : symbol-processing-common-deps. **Version** : 2.3.6.
-     * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : com.google.devtools.ksp. **Name** : symbol-processing-common-deps. **Version** : 2.3.9.
-     * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.devtools.ksp. **Name** : symbol-processing-gradle-plugin. **Version** : 2.3.6.
      * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -17102,27 +17009,11 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
      * **Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
      * **License:** [BSD 3-Clause](http://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-gradle-plugin. **Version** : 0.9.6.
-     * **Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
-     * **License:** [BSD 3-Clause](http://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 4.34.1.
-     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
 1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 4.35.0.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 4.34.1.
-     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
 1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 4.35.0.
-     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 4.34.1.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
@@ -17147,25 +17038,13 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
 1.  **Group** : com.google.truth.extensions. **Name** : truth-proto-extension. **Version** : 1.4.5.
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.palantir.javaformat. **Name** : palantir-java-format. **Version** : 2.75.0.
-     * **Project URL:** [https://github.com/palantir/palantir-java-format](https://github.com/palantir/palantir-java-format)
-     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
 1.  **Group** : com.palantir.javaformat. **Name** : palantir-java-format. **Version** : 2.91.0.
-     * **Project URL:** [https://github.com/palantir/palantir-java-format](https://github.com/palantir/palantir-java-format)
-     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : com.palantir.javaformat. **Name** : palantir-java-format-spi. **Version** : 2.75.0.
      * **Project URL:** [https://github.com/palantir/palantir-java-format](https://github.com/palantir/palantir-java-format)
      * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
 1.  **Group** : com.palantir.javaformat. **Name** : palantir-java-format-spi. **Version** : 2.91.0.
      * **Project URL:** [https://github.com/palantir/palantir-java-format](https://github.com/palantir/palantir-java-format)
      * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : com.sksamuel.aedile. **Name** : aedile-core. **Version** : 2.1.2.
-     * **Project URL:** [http://www.github.com/sksamuel/aedile](http://www.github.com/sksamuel/aedile)
-     * **License:** [The Apache 2.0 License](https://opensource.org/licenses/Apache-2.0)
 
 1.  **Group** : com.sksamuel.aedile. **Name** : aedile-core. **Version** : 3.0.4.
      * **Project URL:** [https://www.github.com/sksamuel/aedile](https://www.github.com/sksamuel/aedile)
@@ -17290,10 +17169,6 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
      * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
 
-1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.37.0.
-     * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
-     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
-
 1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 4.2.0.
      * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
      * **License:** [The MIT License](https://opensource.org/licenses/MIT)
@@ -17310,10 +17185,6 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
 1.  **Group** : org.freemarker. **Name** : freemarker. **Version** : 2.3.32.
      * **Project URL:** [https://freemarker.apache.org/](https://freemarker.apache.org/)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.functionaljava. **Name** : functionaljava. **Version** : 4.8.
-     * **Project URL:** [http://functionaljava.org/](http://functionaljava.org/)
-     * **License:** [The BSD3 License](https://github.com/functionaljava/functionaljava/blob/master/etc/LICENCE)
 
 1.  **Group** : org.functionaljava. **Name** : functionaljava. **Version** : 5.0.
      * **Project URL:** [http://functionaljava.org/](http://functionaljava.org/)
@@ -17556,7 +17427,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
+This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -17908,11 +17779,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
      * **Project URL:** [https://github.com/google/gson](https://github.com/google/gson)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.6.
-     * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.devtools.ksp. **Name** : symbol-processing. **Version** : 2.3.9.
+1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.9.
      * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -18733,7 +18600,7 @@ This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 20:57:13 WEST 2026** using 
+This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -19715,7 +19582,7 @@ This report was generated on **Thu Jun 11 20:57:13 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 20:57:13 WEST 2026** using 
+This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -20067,11 +19934,7 @@ This report was generated on **Thu Jun 11 20:57:13 WEST 2026** using
      * **Project URL:** [https://github.com/google/gson](https://github.com/google/gson)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.6.
-     * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.devtools.ksp. **Name** : symbol-processing. **Version** : 2.3.9.
+1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.9.
      * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -20892,7 +20755,7 @@ This report was generated on **Thu Jun 11 20:57:13 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 20:57:13 WEST 2026** using 
+This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -21874,6 +21737,6 @@ This report was generated on **Thu Jun 11 20:57:13 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 20:57:13 WEST 2026** using 
+This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:core-jvm-annotation:2.0.0-SNAPSHOT.070`
+# Dependencies of `io.spine.tools:core-jvm-annotation:2.0.0-SNAPSHOT.072`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -1162,14 +1162,996 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using 
+This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-base:2.0.0-SNAPSHOT.070`
+# Dependencies of `io.spine.tools:core-jvm-annotation-tests:2.0.0-SNAPSHOT.072`
+
+## Runtime
+1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
+     * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.14.0.
+     * **Project URL:** [https://github.com/google/gson](https://github.com/google/gson)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.36.0.
+     * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.3.
+     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : guava. **Version** : 33.6.0-jre.
+     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.j2objc. **Name** : j2objc-annotations. **Version** : 3.1.
+     * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 4.35.0.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 4.35.0.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 4.35.0.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 26.1.0.
+     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-bom. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : atomicfu. **Version** : 0.29.0.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.atomicfu](https://github.com/Kotlin/kotlinx.atomicfu)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : atomicfu-jvm. **Version** : 0.29.0.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.atomicfu](https://github.com/Kotlin/kotlinx.atomicfu)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-bom. **Version** : 1.10.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-datetime. **Version** : 0.7.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx-datetime](https://github.com/Kotlin/kotlinx-datetime)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-datetime-jvm. **Version** : 0.7.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx-datetime](https://github.com/Kotlin/kotlinx-datetime)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jspecify. **Name** : jspecify. **Version** : 1.0.0.
+     * **Project URL:** [http://jspecify.org/](http://jspecify.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+## Compile, tests, and tooling
+1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/FasterXML/jackson-bom](https://github.com/FasterXML/jackson-bom)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.22.
+     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-xml. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/FasterXML/jackson-dataformat-xml](https://github.com/FasterXML/jackson-dataformat-xml)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-yaml. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/FasterXML/jackson-dataformats-text](https://github.com/FasterXML/jackson-dataformats-text)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.datatype. **Name** : jackson-datatype-guava. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/FasterXML/jackson-datatypes-collections](https://github.com/FasterXML/jackson-datatypes-collections)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.datatype. **Name** : jackson-datatype-jdk8. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8](https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.datatype. **Name** : jackson-datatype-jsr310. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310](https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-parameter-names. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names](https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.woodstox. **Name** : woodstox-core. **Version** : 7.2.0.
+     * **Project URL:** [https://github.com/FasterXML/woodstox](https://github.com/FasterXML/woodstox)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.2.4.
+     * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.github.kevinstern. **Name** : software-and-algorithms. **Version** : 1.0.
+     * **Project URL:** [https://www.github.com/KevinStern/software-and-algorithms](https://www.github.com/KevinStern/software-and-algorithms)
+     * **License:** [MIT License](http://www.opensource.org/licenses/mit-license.php)
+
+1.  **Group** : com.github.oowekyala.ooxml. **Name** : nice-xml-messages. **Version** : 3.1.
+     * **Project URL:** [https://github.com/oowekyala/nice-xml-messages](https://github.com/oowekyala/nice-xml-messages)
+     * **License:** [MIT License](https://github.com/oowekyala/nice-xml-messages/tree/master/LICENSE)
+
+1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
+     * **Project URL:** [http://source.android.com/](http://source.android.com/)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : com.google.api.grpc. **Name** : proto-google-common-protos. **Version** : 2.64.1.
+     * **Project URL:** [https://github.com/googleapis/sdk-platform-java](https://github.com/googleapis/sdk-platform-java)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.auto. **Name** : auto-common. **Version** : 1.2.2.
+     * **Project URL:** [https://github.com/google/auto/tree/main/common](https://github.com/google/auto/tree/main/common)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.auto.service. **Name** : auto-service-annotations. **Version** : 1.1.1.
+     * **Project URL:** [https://github.com/google/auto/tree/main/service](https://github.com/google/auto/tree/main/service)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.11.1.
+     * **Project URL:** [https://github.com/google/auto/tree/main/value](https://github.com/google/auto/tree/main/value)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
+     * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.14.0.
+     * **Project URL:** [https://github.com/google/gson](https://github.com/google/gson)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotation. **Version** : 2.36.0.
+     * **Project URL:** [https://errorprone.info/error_prone_annotation](https://errorprone.info/error_prone_annotation)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.36.0.
+     * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_check_api. **Version** : 2.36.0.
+     * **Project URL:** [https://errorprone.info/error_prone_check_api](https://errorprone.info/error_prone_check_api)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_core. **Version** : 2.36.0.
+     * **Project URL:** [https://errorprone.info/error_prone_core](https://errorprone.info/error_prone_core)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.36.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
+     * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
+     * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.7.4.
+     * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
+     * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.googlejavaformat. **Name** : google-java-format. **Version** : 1.19.1.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.3.
+     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : guava. **Version** : 33.6.0-jre.
+     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : guava-testlib. **Version** : 33.6.0-jre.
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.j2objc. **Name** : j2objc-annotations. **Version** : 3.1.
+     * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-gradle-plugin. **Version** : 0.10.0.
+     * **Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
+     * **License:** [BSD 3-Clause](http://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 4.35.0.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 4.35.0.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 4.35.0.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 4.35.0.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.4.5.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.truth.extensions. **Name** : truth-java8-extension. **Version** : 1.4.5.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.truth.extensions. **Name** : truth-liteproto-extension. **Version** : 1.4.5.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.truth.extensions. **Name** : truth-proto-extension. **Version** : 1.4.5.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.palantir.javaformat. **Name** : palantir-java-format. **Version** : 2.91.0.
+     * **Project URL:** [https://github.com/palantir/palantir-java-format](https://github.com/palantir/palantir-java-format)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : com.palantir.javaformat. **Name** : palantir-java-format-spi. **Version** : 2.91.0.
+     * **Project URL:** [https://github.com/palantir/palantir-java-format](https://github.com/palantir/palantir-java-format)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 10.12.1.
+     * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
+     * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
+
+1.  **Group** : com.sksamuel.aedile. **Name** : aedile-core. **Version** : 3.0.4.
+     * **Project URL:** [https://www.github.com/sksamuel/aedile](https://www.github.com/sksamuel/aedile)
+     * **License:** [The Apache 2.0 License](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
+
+1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
+     * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.squareup. **Name** : kotlinpoet. **Version** : 2.3.0.
+     * **Project URL:** [https://github.com/square/kotlinpoet](https://github.com/square/kotlinpoet)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.squareup. **Name** : kotlinpoet-jvm. **Version** : 2.3.0.
+     * **Project URL:** [https://github.com/square/kotlinpoet](https://github.com/square/kotlinpoet)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
+     * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : commons-codec. **Name** : commons-codec. **Version** : 1.22.0.
+     * **Project URL:** [https://commons.apache.org/proper/commons-codec/](https://commons.apache.org/proper/commons-codec/)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : commons-collections. **Name** : commons-collections. **Version** : 3.2.2.
+     * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : dev.drewhamilton.poko. **Name** : poko-annotations. **Version** : 0.17.1.
+     * **Project URL:** [https://github.com/drewhamilton/Poko](https://github.com/drewhamilton/Poko)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : dev.drewhamilton.poko. **Name** : poko-annotations-jvm. **Version** : 0.17.1.
+     * **Project URL:** [https://github.com/drewhamilton/Poko](https://github.com/drewhamilton/Poko)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : info.picocli. **Name** : picocli. **Version** : 4.7.4.
+     * **Project URL:** [https://picocli.info](https://picocli.info)
+     * **License:** [The Apache Software License, version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.davidburstrom.contester. **Name** : contester-breakpoint. **Version** : 0.2.0.
+     * **Project URL:** [https://github.com/davidburstrom/contester](https://github.com/davidburstrom/contester)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.detekt.sarif4k. **Name** : sarif4k. **Version** : 0.6.0.
+     * **Project URL:** [https://detekt.github.io/detekt](https://detekt.github.io/detekt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.detekt.sarif4k. **Name** : sarif4k-jvm. **Version** : 0.6.0.
+     * **Project URL:** [https://detekt.github.io/detekt](https://detekt.github.io/detekt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.eisop. **Name** : dataflow-errorprone. **Version** : 3.41.0-eisop1.
+     * **Project URL:** [https://eisop.github.io/](https://eisop.github.io/)
+     * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
+
+1.  **Group** : io.github.java-diff-utils. **Name** : java-diff-utils. **Version** : 4.17.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-api. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-cli. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-core. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-metrics. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-parser. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-psi-utils. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-html. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-md. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-sarif. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-txt. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-xml. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-complexity. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-coroutines. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-documentation. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-empty. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-errorprone. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-exceptions. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-naming. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-performance. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-style. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-tooling. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-utils. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.grpc. **Name** : grpc-api. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-bom. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-context. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-core. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-inprocess. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-kotlin-stub. **Version** : 1.4.1.
+     * **Project URL:** [https://github.com/grpc/grpc-kotlin](https://github.com/grpc/grpc-kotlin)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-protobuf. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-protobuf-lite. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-stub. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-assertions-core. **Version** : 6.1.11.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-assertions-core-jvm. **Version** : 6.1.11.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-assertions-shared. **Version** : 6.1.11.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-assertions-shared-jvm. **Version** : 6.1.11.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-common. **Version** : 6.1.11.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-common-jvm. **Version** : 6.1.11.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.perfmark. **Name** : perfmark-api. **Version** : 0.27.0.
+     * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
+     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
+     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
+
+1.  **Group** : javax.inject. **Name** : javax.inject. **Version** : 1.
+     * **Project URL:** [http://code.google.com/p/atinject/](http://code.google.com/p/atinject/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : junit. **Name** : junit. **Version** : 4.13.2.
+     * **Project URL:** [http://junit.org](http://junit.org)
+     * **License:** [Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html)
+
+1.  **Group** : net.sf.saxon. **Name** : Saxon-HE. **Version** : 12.2.
+     * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
+     * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
+
+1.  **Group** : net.sf.saxon. **Name** : Saxon-HE. **Version** : 12.9.
+     * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
+     * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
+
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-ant. **Version** : 7.25.0.
+     * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
+
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 7.25.0.
+     * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
+
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 7.25.0.
+     * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
+
+1.  **Group** : org.antlr. **Name** : antlr4-runtime. **Version** : 4.11.1.
+     * **Project URL:** [https://www.antlr.org/](https://www.antlr.org/)
+     * **License:** [BSD-3-Clause](https://www.antlr.org/license.html)
+
+1.  **Group** : org.antlr. **Name** : antlr4-runtime. **Version** : 4.13.2.
+     * **Project URL:** [https://www.antlr.org/](https://www.antlr.org/)
+     * **License:** [BSD-3-Clause](https://www.antlr.org/license.html)
+
+1.  **Group** : org.apache.commons. **Name** : commons-lang3. **Version** : 3.20.0.
+     * **Project URL:** [https://commons.apache.org/proper/commons-lang/](https://commons.apache.org/proper/commons-lang/)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents.client5. **Name** : httpclient5. **Version** : 5.1.3.
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents.core5. **Name** : httpcore5. **Version** : 5.1.3.
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents.core5. **Name** : httpcore5-h2. **Version** : 5.1.3.
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.logging.log4j. **Name** : log4j-api. **Version** : 2.20.0.
+     * **Project URL:** [https://www.apache.org/](https://www.apache.org/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.logging.log4j. **Name** : log4j-core. **Version** : 2.20.0.
+     * **Project URL:** [https://www.apache.org/](https://www.apache.org/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.2.
+     * **Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.checkerframework. **Name** : checker-compat-qual. **Version** : 2.5.3.
+     * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
+     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
+
+1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 4.2.0.
+     * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
+     * **License:** [The MIT License](https://opensource.org/licenses/MIT)
+
+1.  **Group** : org.codehaus.mojo. **Name** : animal-sniffer-annotations. **Version** : 1.27.
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [MIT license](https://spdx.org/licenses/MIT.txt)
+
+1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.3.0.
+     * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The BSD 2-Clause License](http://www.opensource.org/licenses/bsd-license.php)
+
+1.  **Group** : org.freemarker. **Name** : freemarker. **Version** : 2.3.32.
+     * **Project URL:** [https://freemarker.apache.org/](https://freemarker.apache.org/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.functionaljava. **Name** : functionaljava. **Version** : 5.0.
+     * **Project URL:** [http://functionaljava.org/](http://functionaljava.org/)
+     * **License:** [The BSD3 License](https://github.com/functionaljava/functionaljava/blob/master/etc/LICENCE)
+
+1.  **Group** : org.hamcrest. **Name** : hamcrest. **Version** : 3.0.
+     * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
+     * **License:** [BSD-3-Clause](https://raw.githubusercontent.com/hamcrest/JavaHamcrest/master/LICENSE)
+
+1.  **Group** : org.hamcrest. **Name** : hamcrest-core. **Version** : 3.0.
+     * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
+     * **License:** [BSD-3-Clause](https://raw.githubusercontent.com/hamcrest/JavaHamcrest/master/LICENSE)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.15.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.15.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.15.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.javassist. **Name** : javassist. **Version** : 3.28.0-GA.
+     * **Project URL:** [http://www.javassist.org/](http://www.javassist.org/)
+     * **License:** [Apache License 2.0](http://www.apache.org/licenses/)
+     * **License:** [LGPL 2.1](http://www.gnu.org/licenses/lgpl-2.1.html)
+     * **License:** [MPL 1.1](http://www.mozilla.org/MPL/MPL-1.1.html)
+
+1.  **Group** : org.jboss.forge.roaster. **Name** : roaster-api. **Version** : 2.31.0.Final.
+     * **License:** [Eclipse Public License version 1.0](https://www.eclipse.org/legal/epl-v10.html)
+
+1.  **Group** : org.jboss.forge.roaster. **Name** : roaster-jdt. **Version** : 2.31.0.Final.
+     * **License:** [Eclipse Public License version 1.0](https://www.eclipse.org/legal/epl-v10.html)
+
+1.  **Group** : org.jcommander. **Name** : jcommander. **Version** : 1.85.
+     * **Project URL:** [https://jcommander.org](https://jcommander.org)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 26.1.0.
+     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : markdown. **Version** : 0.7.3.
+     * **Project URL:** [https://github.com/JetBrains/markdown](https://github.com/JetBrains/markdown)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : markdown-jvm. **Version** : 0.7.3.
+     * **Project URL:** [https://github.com/JetBrains/markdown](https://github.com/JetBrains/markdown)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : analysis-kotlin-symbols. **Version** : 2.2.0.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : analysis-markdown. **Version** : 2.2.0.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : dokka-base. **Version** : 2.2.0.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : dokka-core. **Version** : 2.2.0.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 2.2.0.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 2.2.0.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : templating-plugin. **Version** : 2.2.0.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : trove4j. **Version** : 1.0.20200330.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
+     * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : abi-tools. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : abi-tools-api. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-bom. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-build-tools-api. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-build-tools-compat. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-build-tools-cri-impl. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-build-tools-impl. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 2.0.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-runner. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-client. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 2.0.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-gradle-plugin-annotations. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-gradle-plugin-api. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-gradle-plugins-bom. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-abi-reader. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-metadata-jvm. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-native-utils. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 2.0.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 2.0.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 2.0.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 2.0.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 2.0.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 2.0.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-tooling-core. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-util-io. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : atomicfu. **Version** : 0.29.0.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.atomicfu](https://github.com/Kotlin/kotlinx.atomicfu)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : atomicfu-jvm. **Version** : 0.29.0.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.atomicfu](https://github.com/Kotlin/kotlinx.atomicfu)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-bom. **Version** : 1.10.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.10.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.10.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.6.4.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-jdk8. **Version** : 1.10.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-test. **Version** : 1.10.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-test-jvm. **Version** : 1.10.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-datetime. **Version** : 0.7.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx-datetime](https://github.com/Kotlin/kotlinx-datetime)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-datetime-jvm. **Version** : 0.7.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx-datetime](https://github.com/Kotlin/kotlinx-datetime)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-html-jvm. **Version** : 0.8.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.html](https://github.com/Kotlin/kotlinx.html)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-html-jvm. **Version** : 0.9.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.html](https://github.com/Kotlin/kotlinx.html)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core. **Version** : 1.4.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core-jvm. **Version** : 1.4.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json. **Version** : 1.4.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json-jvm. **Version** : 1.4.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jsoup. **Name** : jsoup. **Version** : 1.16.1.
+     * **Project URL:** [https://jsoup.org/](https://jsoup.org/)
+     * **License:** [The MIT License](https://jsoup.org/license)
+
+1.  **Group** : org.jspecify. **Name** : jspecify. **Version** : 1.0.0.
+     * **Project URL:** [http://jspecify.org/](http://jspecify.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.junit. **Name** : junit-bom. **Version** : 6.1.0.
+     * **Project URL:** [https://junit.org/](https://junit.org/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit-pioneer. **Name** : junit-pioneer. **Version** : 2.3.0.
+     * **Project URL:** [https://junit-pioneer.org/](https://junit-pioneer.org/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-api. **Version** : 6.1.0.
+     * **Project URL:** [https://junit.org/](https://junit.org/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-engine. **Version** : 6.1.0.
+     * **Project URL:** [https://junit.org/](https://junit.org/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-params. **Version** : 6.1.0.
+     * **Project URL:** [https://junit.org/](https://junit.org/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.platform. **Name** : junit-platform-commons. **Version** : 6.1.0.
+     * **Project URL:** [https://junit.org/](https://junit.org/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.platform. **Name** : junit-platform-engine. **Version** : 6.1.0.
+     * **Project URL:** [https://junit.org/](https://junit.org/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.platform. **Name** : junit-platform-launcher. **Version** : 6.1.0.
+     * **Project URL:** [https://junit.org/](https://junit.org/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.opentest4j. **Name** : opentest4j. **Version** : 1.3.0.
+     * **Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.10.1.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm-commons. **Version** : 9.10.1.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm-tree. **Version** : 9.10.1.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.pcollections. **Name** : pcollections. **Version** : 4.0.1.
+     * **Project URL:** [https://github.com/hrldcpr/pcollections](https://github.com/hrldcpr/pcollections)
+     * **License:** [The MIT License](https://opensource.org/licenses/mit-license.php)
+
+1.  **Group** : org.pcollections. **Name** : pcollections. **Version** : 4.0.2.
+     * **Project URL:** [https://github.com/hrldcpr/pcollections](https://github.com/hrldcpr/pcollections)
+     * **License:** [The MIT License](https://opensource.org/licenses/mit-license.php)
+
+1.  **Group** : org.reflections. **Name** : reflections. **Version** : 0.10.2.
+     * **Project URL:** [http://github.com/ronmamo/reflections](http://github.com/ronmamo/reflections)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [WTFPL](http://www.wtfpl.net/)
+
+1.  **Group** : org.slf4j. **Name** : jul-to-slf4j. **Version** : 1.7.36.
+     * **Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
+     * **License:** [MIT License](http://www.opensource.org/licenses/mit-license.php)
+
+1.  **Group** : org.snakeyaml. **Name** : snakeyaml-engine. **Version** : 2.7.
+     * **Project URL:** [https://bitbucket.org/snakeyaml/snakeyaml-engine](https://bitbucket.org/snakeyaml/snakeyaml-engine)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.xmlresolver. **Name** : xmlresolver. **Version** : 5.1.2.
+     * **Project URL:** [https://github.com/xmlresolver/xmlresolver](https://github.com/xmlresolver/xmlresolver)
+     * **License:** [Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : org.xmlresolver. **Name** : xmlresolver. **Version** : 5.3.3.
+     * **Project URL:** [https://github.com/xmlresolver/xmlresolver](https://github.com/xmlresolver/xmlresolver)
+     * **License:** [Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : org.yaml. **Name** : snakeyaml. **Version** : 2.5.
+     * **Project URL:** [https://bitbucket.org/snakeyaml/snakeyaml](https://bitbucket.org/snakeyaml/snakeyaml)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+
+The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
+
+This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
+[Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
+[Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+
+
+
+
+# Dependencies of `io.spine.tools:core-jvm-base:2.0.0-SNAPSHOT.072`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -2339,14 +3321,14 @@ This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using 
+This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-comparable:2.0.0-SNAPSHOT.070`
+# Dependencies of `io.spine.tools:core-jvm-comparable:2.0.0-SNAPSHOT.072`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -3508,14 +4490,14 @@ This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using 
+This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-comparable-tests:2.0.0-SNAPSHOT.070`
+# Dependencies of `io.spine.tools:core-jvm-comparable-tests:2.0.0-SNAPSHOT.072`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4490,14 +5472,14 @@ This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using 
+This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-entity:2.0.0-SNAPSHOT.070`
+# Dependencies of `io.spine.tools:core-jvm-entity:2.0.0-SNAPSHOT.072`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -5659,14 +6641,14 @@ This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using 
+This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-entity-tests:2.0.0-SNAPSHOT.070`
+# Dependencies of `io.spine.tools:core-jvm-entity-tests:2.0.0-SNAPSHOT.072`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6641,14 +7623,14 @@ This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using 
+This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-grpc:2.0.0-SNAPSHOT.070`
+# Dependencies of `io.spine.tools:core-jvm-grpc:2.0.0-SNAPSHOT.072`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -7781,14 +8763,14 @@ This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using 
+This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-ksp:2.0.0-SNAPSHOT.070`
+# Dependencies of `io.spine.tools:core-jvm-ksp:2.0.0-SNAPSHOT.072`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -8997,14 +9979,14 @@ This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using 
+This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-marker:2.0.0-SNAPSHOT.070`
+# Dependencies of `io.spine.tools:core-jvm-marker:2.0.0-SNAPSHOT.072`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -10174,14 +11156,14 @@ This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using 
+This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-marker-tests:2.0.0-SNAPSHOT.070`
+# Dependencies of `io.spine.tools:core-jvm-marker-tests:2.0.0-SNAPSHOT.072`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -11156,14 +12138,14 @@ This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using 
+This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-message-group:2.0.0-SNAPSHOT.070`
+# Dependencies of `io.spine.tools:core-jvm-message-group:2.0.0-SNAPSHOT.072`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -12333,14 +13315,14 @@ This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using 
+This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-message-group-tests:2.0.0-SNAPSHOT.070`
+# Dependencies of `io.spine.tools:core-jvm-message-group-tests:2.0.0-SNAPSHOT.072`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -13315,14 +14297,14 @@ This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using 
+This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-plugins:2.0.0-SNAPSHOT.070`
+# Dependencies of `io.spine.tools:core-jvm-plugins:2.0.0-SNAPSHOT.072`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -14547,14 +15529,14 @@ This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using 
+This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-routing:2.0.0-SNAPSHOT.070`
+# Dependencies of `io.spine.tools:core-jvm-routing:2.0.0-SNAPSHOT.072`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -15796,14 +16778,14 @@ This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using 
+This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-routing-tests:2.0.0-SNAPSHOT.070`
+# Dependencies of `io.spine.tools:core-jvm-routing-tests:2.0.0-SNAPSHOT.072`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -16574,14 +17556,14 @@ This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using 
+This report was generated on **Thu Jun 11 20:57:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-signal:2.0.0-SNAPSHOT.070`
+# Dependencies of `io.spine.tools:core-jvm-signal:2.0.0-SNAPSHOT.072`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -17751,14 +18733,14 @@ This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using 
+This report was generated on **Thu Jun 11 20:57:13 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-signal-tests:2.0.0-SNAPSHOT.070`
+# Dependencies of `io.spine.tools:core-jvm-signal-tests:2.0.0-SNAPSHOT.072`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -18733,14 +19715,14 @@ This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using 
+This report was generated on **Thu Jun 11 20:57:13 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-uuid:2.0.0-SNAPSHOT.070`
+# Dependencies of `io.spine.tools:core-jvm-uuid:2.0.0-SNAPSHOT.072`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -19910,14 +20892,14 @@ This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using 
+This report was generated on **Thu Jun 11 20:57:13 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-uuid-tests:2.0.0-SNAPSHOT.070`
+# Dependencies of `io.spine.tools:core-jvm-uuid-tests:2.0.0-SNAPSHOT.072`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -20892,6 +21874,6 @@ This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 11 16:23:20 WEST 2026** using 
+This report was generated on **Thu Jun 11 20:57:13 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -98,25 +98,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>compiler-api</artifactId>
-    <version>2.0.0-SNAPSHOT.051</version>
+    <version>2.0.0-SNAPSHOT.052</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>compiler-gradle-api</artifactId>
-    <version>2.0.0-SNAPSHOT.051</version>
+    <version>2.0.0-SNAPSHOT.052</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>compiler-jvm</artifactId>
-    <version>2.0.0-SNAPSHOT.051</version>
+    <version>2.0.0-SNAPSHOT.052</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>compiler-params</artifactId>
-    <version>2.0.0-SNAPSHOT.051</version>
+    <version>2.0.0-SNAPSHOT.052</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -218,13 +218,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>compiler-gradle-plugin</artifactId>
-    <version>2.0.0-SNAPSHOT.051</version>
+    <version>2.0.0-SNAPSHOT.052</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>compiler-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.051</version>
+    <version>2.0.0-SNAPSHOT.052</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -313,11 +313,6 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>com.google.devtools.ksp</groupId>
-    <artifactId>symbol-processing</artifactId>
-    <version>2.3.9</version>
-  </dependency>
-  <dependency>
-    <groupId>com.google.devtools.ksp</groupId>
     <artifactId>symbol-processing-api</artifactId>
     <version>2.3.9</version>
   </dependency>
@@ -367,17 +362,17 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>compiler-cli-all</artifactId>
-    <version>2.0.0-SNAPSHOT.051</version>
+    <version>2.0.0-SNAPSHOT.052</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>compiler-protoc-plugin</artifactId>
-    <version>2.0.0-SNAPSHOT.051</version>
+    <version>2.0.0-SNAPSHOT.052</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>core-jvm-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.069</version>
+    <version>2.0.0-SNAPSHOT.070</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>core-jvm-compiler</artifactId>
-<version>2.0.0-SNAPSHOT.070</version>
+<version>2.0.0-SNAPSHOT.072</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -56,12 +56,6 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-annotations</artifactId>
-    <version>2.0.0-SNAPSHOT.410</version>
-    <scope>compile</scope>
-  </dependency>
-  <dependency>
-    <groupId>io.spine</groupId>
-    <artifactId>spine-base</artifactId>
     <version>2.0.0-SNAPSHOT.410</version>
     <scope>compile</scope>
   </dependency>
@@ -207,6 +201,12 @@ all modules and does not describe the project structure per-subproject.
     <groupId>io.kotest</groupId>
     <artifactId>kotest-assertions-core</artifactId>
     <version>6.1.11</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.spine</groupId>
+    <artifactId>spine-base</artifactId>
+    <version>2.0.0-SNAPSHOT.410</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,5 +29,5 @@
  *
  * Do not rename this property, as it is also used in the integration tests via its name.
  */
-val coreJvmCompilerVersion by extra("2.0.0-SNAPSHOT.070")
+val coreJvmCompilerVersion by extra("2.0.0-SNAPSHOT.071")
 val versionToPublish by extra(coreJvmCompilerVersion)

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,5 +29,5 @@
  *
  * Do not rename this property, as it is also used in the integration tests via its name.
  */
-val coreJvmCompilerVersion by extra("2.0.0-SNAPSHOT.071")
+val coreJvmCompilerVersion by extra("2.0.0-SNAPSHOT.072")
 val versionToPublish by extra(coreJvmCompilerVersion)


### PR DESCRIPTION
## What

Raises test coverage of the `annotation` and `base` modules and fixes four production defects the new tests uncovered.

### Coverage (per-module Kover, lines)

| Module | Before | After (lines / branches) |
|---|---|---|
| `base` | 0% (module had no `src/test`) | **96.8%** (733/757) / 89.1% |
| `annotation` | 27.0% | **96.3%** (519/539) / 82.3% |

The "after" figures are the per-module Kover reports with cross-module test coverage credited
via `creditTestCoverageFrom(...)`: `annotation` credits the in-process pipeline suite of the new
`annotation-tests` module, and `base` credits `entity-tests` (which exercises `AddFieldClass`).
The remaining uncovered lines are non-actionable in unit scope: the gRPC-root rendering path
of `ServiceAnnotationRenderer` (needs gRPC codegen), IO-failure guards, and test-fixture
infrastructure. The unused `EnumAnnotationsView.Repository` (dead code duplicating the `@Route`
companion functions) is removed instead of being tested.

Per-module Kover reports previously could not see coverage produced by sibling `*-tests` modules
(the established home for pipeline tests, per `TESTING.md`). The new `creditTestCoverageFrom(...)`
wiring merges that execution data into the owning module's own report, so the per-module numbers
now reflect the full test surface.

### New tests

- **`base/src/test`** — 24 specs covering the `field`, `gradle`, `gradle.settings`, `gradle.module`, `settings`, and root packages, with a `farm.proto` fixture providing every field shape (singular/repeated/map, message/enum/primitive, nested types).
- **`annotation/src/test`** — unit specs for `ApiOption`, routing extensions, `WithOptions`, view routes, and the `FieldAccessors` insertion point.
- **`annotation-tests`** (new module, mirrors `marker-tests` per `TESTING.md`) — in-JVM `PipelineSetup` specs driving `ApiAnnotationsPlugin` end-to-end over a fixture matrix of all API-level options. Unlike the TestKit-based IgTest (whose codegen runs in a separate JVM no agent instruments), these runs produce coverage and assert rendered code directly.

### Production fixes (each emerged from a failing new test)

1. `GeneratedAnnotation.forJavaPoet` used KotlinPoet's `%L` placeholder, which JavaPoet ignores — the version string was silently dropped from `@Generated` annotations.
2. `ModuleOptions.applyDependencies` passed a `LazyDependency` object where Gradle expects a dependency notation, crashing any build that touched `coreJvm.module`.
3. `FileOptionsProcess` never emitted `FileOptionMatched` for enums, so file-wide options (`internal_all` etc.) never annotated generated Java enums.
4. Annotators ignored option *values*: `(internal_type) = false` could not revert `(internal_all) = true`, and `MessageOrEnumAnnotator.needsAnnotation` compared whole `Option` messages (never matching compiler-produced options). All annotators now filter by `isTrue()`. The previously vacuous IgTest check for this case is now non-vacuous and passes.

### Versioning & build infrastructure

`2.0.0-SNAPSHOT.070 → .071 → .072`. The second bump is the sanctioned re-bump: `.071` had been
published to Maven Local before the fixes landed, and stale same-version artifacts contaminated
TestKit/daemon caches (see the new `igtest-stale-plugins` and `prototap-build-cache` team memories).

Build-cache hardening that this PR's CI runs surfaced:

- Protoc tasks (`GenerateProtoTask`) are no longer build-cached in this repository: the protoc
  plugins in use (ProtoTap in `*-tests` modules, the Spine Compiler protoc plugin elsewhere) write
  captures and descriptor references as undeclared side effects, so a cache hit broke downstream
  codegen and `PipelineSetup`-based suites (`:comparable-tests:test` on CI).
- Spine Compiler is bumped to `2.0.0-SNAPSHOT.052` (and the dogfooded CoreJvm Compiler
  to `2.0.0-SNAPSHOT.070`), which declare their task outputs correctly, so the
  `launchSpineCompiler` tasks stay cacheable.

## Pre-PR verification

- `./gradlew clean build dokkaGenerate --no-build-cache` — green (736 tasks).
- Reviewers: `spine-code-review` and `review-docs` — approve with changes; `kotlin-engineer` — approve. No Must-fix findings.

All reviewer Should-fix items were applied in `c99669e78`:
- `forJavaPoet` / `forKotlinPoet` now use the `$S` / `%S` placeholders, escaping arbitrary values natively.
- The `find { }?.let { return@alter }` existence checks became `any { }` in all three annotation views.
- Test-KDoc fixes: per-constant docs on the annotation-line constants; the `[SettingsWithActions.markAs]` link is fully qualified.
- The inverted comment in `OuterClassAnnotationDiscovery` now matches the routing (`java_multiple_files = false`).

A follow-up commit (`a14cfc0ad`) also fixes the CI failure surfaced by this PR: build-cache hits on `generate*Proto` tasks of ProtoTap modules dropped the `CodeGeneratorRequest.binpb` capture, breaking all `PipelineSetup`-based suites (observed on `:comparable-tests:test`). The root build script now disables build caching for those tasks; the proper fix (declaring captures as task outputs) belongs in the ProtoTap plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



