### PR TITLE
Add memory: run Gradle with a UTF-8 locale

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -10,6 +10,7 @@ See [README.md](README.md) for the format and routing rules.
 ## Project (durable context & rationale)
 
 - [windows-ci-needs-real-symlinks](project/windows-ci-needs-real-symlinks.md) — `tests/` build needs git symlinks checked out natively; never set `core.symlinks false` in Windows CI.
+- [gradle-needs-utf8-locale](project/gradle-needs-utf8-locale.md) — Run Gradle with `LC_ALL=C.UTF-8`; the default POSIX locale makes `sun.jnu.encoding` ASCII and breaks expansion of dependency jars with non-ASCII entries (e.g. KSP).
 
 ## Reference (external systems)
 

--- a/.agents/memory/project/gradle-needs-utf8-locale.md
+++ b/.agents/memory/project/gradle-needs-utf8-locale.md
@@ -1,0 +1,33 @@
+---
+name: gradle-needs-utf8-locale
+description: Run Gradle with `LC_ALL=C.UTF-8`; the default POSIX locale makes `sun.jnu.encoding` ASCII and breaks expansion of dependency jars with non-ASCII entries (e.g. KSP).
+metadata:
+  type: project
+  since: 2026-06-15
+---
+
+In container/CI-like environments the locale often defaults to `POSIX`/`C`,
+which sets the JVM's `sun.jnu.encoding` to ASCII (`ANSI_X3.4-1968`). Gradle
+then cannot write out dependency-jar entries whose names contain non-ASCII
+characters, so any `zipTree`-based task fails. Concretely,
+`:ksp:extractIncludeProto` (the protobuf-gradle-plugin scanning the proto
+path) fails with `Cannot expand ZIP '.../symbol-processing-aa-embeddable-<ver>.jar'`,
+caused by `java.nio.file.InvalidPathException: Malformed input or input
+contains unmappable characters: ksp/javaslang/λ$Memoized.class`. The jar
+itself is fine (`unzip -t` clean, SHA-1 matches the cache path) — only the
+extraction to disk fails.
+
+**Why:** Hit on 2026-06-15 while running `publishToMavenLocal` to verify
+issue #29. `gradle.properties` already sets `-Dfile.encoding=UTF-8`, but that
+does **not** affect file names: `sun.jnu.encoding` is derived from the OS
+locale, not from `-D` system properties, so the build still breaks.
+
+**How to apply:** Run Gradle under a UTF-8 locale, e.g.
+`LC_ALL=C.UTF-8 LANG=C.UTF-8 ./gradlew …` (`C.utf8` is the same locale). Stop
+any daemon started under the old locale first (`./gradlew --stop`) — a daemon
+captures `sun.jnu.encoding` at JVM startup, so a lingering POSIX daemon keeps
+failing. Affects every module that pulls KSP (e.g. `:ksp`, `:routing`) and any
+dependency jar carrying non-ASCII entries; the same applies to the `core-jvm`
+consumer build.
+
+Related: [[windows-ci-needs-real-symlinks]]

--- a/.agents/memory/project/gradle-needs-utf8-locale.md
+++ b/.agents/memory/project/gradle-needs-utf8-locale.md
@@ -20,7 +20,10 @@ extraction to disk fails.
 **Why:** Hit on 2026-06-15 while running `publishToMavenLocal` to verify
 issue #29. `gradle.properties` already sets `-Dfile.encoding=UTF-8`, but that
 does **not** affect file names: `sun.jnu.encoding` is derived from the OS
-locale, not from `-D` system properties, so the build still breaks.
+locale, not from `-D` system properties, so the build still breaks. This is a
+known Gradle/JVM limitation, not specific to this repo — see
+[gradle/gradle#13526](https://github.com/gradle/gradle/issues/13526) for the
+same failure on the sibling `kotlin-compiler-embeddable` jar.
 
 **How to apply:** Run Gradle under a UTF-8 locale, e.g.
 `LC_ALL=C.UTF-8 LANG=C.UTF-8 ./gradlew …` (`C.utf8` is the same locale). Stop

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:core-jvm-annotation:2.0.0-SNAPSHOT.072`
+# Dependencies of `io.spine.tools:core-jvm-annotation:2.0.0-SNAPSHOT.073`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -1165,7 +1165,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-annotation-tests:2.0.0-SNAPSHOT.072`
+# Dependencies of `io.spine.tools:core-jvm-annotation-tests:2.0.0-SNAPSHOT.073`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2147,7 +2147,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-base:2.0.0-SNAPSHOT.072`
+# Dependencies of `io.spine.tools:core-jvm-base:2.0.0-SNAPSHOT.073`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -3320,7 +3320,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-comparable:2.0.0-SNAPSHOT.072`
+# Dependencies of `io.spine.tools:core-jvm-comparable:2.0.0-SNAPSHOT.073`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -4485,7 +4485,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-comparable-tests:2.0.0-SNAPSHOT.072`
+# Dependencies of `io.spine.tools:core-jvm-comparable-tests:2.0.0-SNAPSHOT.073`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5467,7 +5467,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-entity:2.0.0-SNAPSHOT.072`
+# Dependencies of `io.spine.tools:core-jvm-entity:2.0.0-SNAPSHOT.073`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -6632,7 +6632,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-entity-tests:2.0.0-SNAPSHOT.072`
+# Dependencies of `io.spine.tools:core-jvm-entity-tests:2.0.0-SNAPSHOT.073`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7614,7 +7614,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-grpc:2.0.0-SNAPSHOT.072`
+# Dependencies of `io.spine.tools:core-jvm-grpc:2.0.0-SNAPSHOT.073`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -8754,7 +8754,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-ksp:2.0.0-SNAPSHOT.072`
+# Dependencies of `io.spine.tools:core-jvm-ksp:2.0.0-SNAPSHOT.073`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -9970,7 +9970,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-marker:2.0.0-SNAPSHOT.072`
+# Dependencies of `io.spine.tools:core-jvm-marker:2.0.0-SNAPSHOT.073`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -11143,7 +11143,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-marker-tests:2.0.0-SNAPSHOT.072`
+# Dependencies of `io.spine.tools:core-jvm-marker-tests:2.0.0-SNAPSHOT.073`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -12125,7 +12125,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-message-group:2.0.0-SNAPSHOT.072`
+# Dependencies of `io.spine.tools:core-jvm-message-group:2.0.0-SNAPSHOT.073`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -13298,7 +13298,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-message-group-tests:2.0.0-SNAPSHOT.072`
+# Dependencies of `io.spine.tools:core-jvm-message-group-tests:2.0.0-SNAPSHOT.073`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -14280,7 +14280,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-plugins:2.0.0-SNAPSHOT.072`
+# Dependencies of `io.spine.tools:core-jvm-plugins:2.0.0-SNAPSHOT.073`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -15512,7 +15512,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-routing:2.0.0-SNAPSHOT.072`
+# Dependencies of `io.spine.tools:core-jvm-routing:2.0.0-SNAPSHOT.073`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -16761,7 +16761,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-routing-tests:2.0.0-SNAPSHOT.072`
+# Dependencies of `io.spine.tools:core-jvm-routing-tests:2.0.0-SNAPSHOT.073`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -17434,7 +17434,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-signal:2.0.0-SNAPSHOT.072`
+# Dependencies of `io.spine.tools:core-jvm-signal:2.0.0-SNAPSHOT.073`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -18607,7 +18607,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-signal-tests:2.0.0-SNAPSHOT.072`
+# Dependencies of `io.spine.tools:core-jvm-signal-tests:2.0.0-SNAPSHOT.073`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -19589,7 +19589,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-uuid:2.0.0-SNAPSHOT.072`
+# Dependencies of `io.spine.tools:core-jvm-uuid:2.0.0-SNAPSHOT.073`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -20762,7 +20762,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-uuid-tests:2.0.0-SNAPSHOT.072`
+# Dependencies of `io.spine.tools:core-jvm-uuid-tests:2.0.0-SNAPSHOT.073`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>core-jvm-compiler</artifactId>
-<version>2.0.0-SNAPSHOT.072</version>
+<version>2.0.0-SNAPSHOT.073</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,5 +29,5 @@
  *
  * Do not rename this property, as it is also used in the integration tests via its name.
  */
-val coreJvmCompilerVersion by extra("2.0.0-SNAPSHOT.072")
+val coreJvmCompilerVersion by extra("2.0.0-SNAPSHOT.073")
 val versionToPublish by extra(coreJvmCompilerVersion)


### PR DESCRIPTION
Record that the default POSIX locale in container/CI-like environments sets `sun.jnu.encoding` to ASCII, which makes Gradle fail to expand dependency jars that carry non-ASCII entries (e.g. the KSP `symbol-processing-aa-embeddable` jar's `ksp/javaslang/λ$Memoized.class`). The remedy is to run Gradle with `LC_ALL=C.UTF-8`. Discovered while verifying issue #29.

https://claude.ai/code/session_01G6WyhUqapFVffwLDFd7JyY