### PR TITLE
Cover rejection codegen for `protobuf()`-scoped dependencies (#33)

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -6,6 +6,7 @@ See [README.md](README.md) for the format and routing rules.
 ## Feedback (validated patterns & corrections)
 
 - [copilot-review-request](feedback/copilot-review-request.md) — GraphQL `requestReviews` with `botIds: ["BOT_kgDOCnlnWA"]`; REST endpoint silently no-ops on re-requests.
+- [no-issue-references-in-code](feedback/no-issue-references-in-code.md) — Don't put issue/PR refs in code (comments, KDoc, fixtures); cross-link the issue and PR instead.
 
 ## Project (durable context & rationale)
 

--- a/.agents/memory/feedback/no-issue-references-in-code.md
+++ b/.agents/memory/feedback/no-issue-references-in-code.md
@@ -1,0 +1,20 @@
+---
+name: no-issue-references-in-code
+description: Don't put issue/PR references in code (comments, KDoc, fixtures); cross-link the issue and PR to each other instead.
+metadata:
+  type: feedback
+  since: 2026-06-16
+---
+
+Source code — including comments, KDoc/Javadoc, and test fixtures — must not
+carry bare issue or PR references such as `See issue #33`. Describe the
+rationale inline so the code reads as self-contained.
+
+**Why:** Issue numbers embedded in code rot over time and force readers to
+leave the codebase to understand intent. Traceability already lives in the
+issue ↔ PR link: let the issue reference the PR, or the PR reference the
+issue — but not the code. Raised by @alexander-yevsyukov in review of PR #96.
+
+**How to apply:** When documenting why a piece of code or a test fixture
+exists, explain it in prose in place. Keep issue/PR cross-references in the PR
+description or the issue thread, never in source files.

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:core-jvm-annotation:2.0.0-SNAPSHOT.073`
+# Dependencies of `io.spine.tools:core-jvm-annotation:2.0.0-SNAPSHOT.074`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -1165,7 +1165,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-annotation-tests:2.0.0-SNAPSHOT.073`
+# Dependencies of `io.spine.tools:core-jvm-annotation-tests:2.0.0-SNAPSHOT.074`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2147,7 +2147,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-base:2.0.0-SNAPSHOT.073`
+# Dependencies of `io.spine.tools:core-jvm-base:2.0.0-SNAPSHOT.074`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -3320,7 +3320,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-comparable:2.0.0-SNAPSHOT.073`
+# Dependencies of `io.spine.tools:core-jvm-comparable:2.0.0-SNAPSHOT.074`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -4485,7 +4485,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-comparable-tests:2.0.0-SNAPSHOT.073`
+# Dependencies of `io.spine.tools:core-jvm-comparable-tests:2.0.0-SNAPSHOT.074`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5467,7 +5467,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-entity:2.0.0-SNAPSHOT.073`
+# Dependencies of `io.spine.tools:core-jvm-entity:2.0.0-SNAPSHOT.074`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -6632,7 +6632,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-entity-tests:2.0.0-SNAPSHOT.073`
+# Dependencies of `io.spine.tools:core-jvm-entity-tests:2.0.0-SNAPSHOT.074`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7614,7 +7614,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-grpc:2.0.0-SNAPSHOT.073`
+# Dependencies of `io.spine.tools:core-jvm-grpc:2.0.0-SNAPSHOT.074`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -8754,7 +8754,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-ksp:2.0.0-SNAPSHOT.073`
+# Dependencies of `io.spine.tools:core-jvm-ksp:2.0.0-SNAPSHOT.074`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -9970,7 +9970,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-marker:2.0.0-SNAPSHOT.073`
+# Dependencies of `io.spine.tools:core-jvm-marker:2.0.0-SNAPSHOT.074`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -11143,7 +11143,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-marker-tests:2.0.0-SNAPSHOT.073`
+# Dependencies of `io.spine.tools:core-jvm-marker-tests:2.0.0-SNAPSHOT.074`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -12125,7 +12125,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-message-group:2.0.0-SNAPSHOT.073`
+# Dependencies of `io.spine.tools:core-jvm-message-group:2.0.0-SNAPSHOT.074`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -13298,7 +13298,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-message-group-tests:2.0.0-SNAPSHOT.073`
+# Dependencies of `io.spine.tools:core-jvm-message-group-tests:2.0.0-SNAPSHOT.074`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -14280,7 +14280,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-plugins:2.0.0-SNAPSHOT.073`
+# Dependencies of `io.spine.tools:core-jvm-plugins:2.0.0-SNAPSHOT.074`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -15512,7 +15512,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-routing:2.0.0-SNAPSHOT.073`
+# Dependencies of `io.spine.tools:core-jvm-routing:2.0.0-SNAPSHOT.074`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -16761,7 +16761,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-routing-tests:2.0.0-SNAPSHOT.073`
+# Dependencies of `io.spine.tools:core-jvm-routing-tests:2.0.0-SNAPSHOT.074`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -17434,7 +17434,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-signal:2.0.0-SNAPSHOT.073`
+# Dependencies of `io.spine.tools:core-jvm-signal:2.0.0-SNAPSHOT.074`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -18607,7 +18607,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-signal-tests:2.0.0-SNAPSHOT.073`
+# Dependencies of `io.spine.tools:core-jvm-signal-tests:2.0.0-SNAPSHOT.074`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -19589,7 +19589,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-uuid:2.0.0-SNAPSHOT.073`
+# Dependencies of `io.spine.tools:core-jvm-uuid:2.0.0-SNAPSHOT.074`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -20762,7 +20762,7 @@ This report was generated on **Thu Jun 11 21:47:45 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-jvm-uuid-tests:2.0.0-SNAPSHOT.073`
+# Dependencies of `io.spine.tools:core-jvm-uuid-tests:2.0.0-SNAPSHOT.074`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>core-jvm-compiler</artifactId>
-<version>2.0.0-SNAPSHOT.073</version>
+<version>2.0.0-SNAPSHOT.074</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/signal/src/test/kotlin/io/spine/tools/core/jvm/signal/rejection/RejectionCodegenIgTest.kt
+++ b/signal/src/test/kotlin/io/spine/tools/core/jvm/signal/rejection/RejectionCodegenIgTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ internal class RejectionCodegenIgTest {
          * The directory where the generated code is expected to be located.
          */
         private const val PACKAGE_DIR = "io/spine/sample/rejections"
-        
+
         private lateinit var moduleDir: File
 
         @TempDir
@@ -214,6 +214,23 @@ internal class RejectionCodegenIgTest {
             assertJavaFileExists(packageDir, "TestRejection1")
             assertJavaFileExists(packageDir, "TestRejection2")
         }
+    }
+
+    /**
+     * Verifies that rejection throwables are generated for `rejections.proto` files
+     * brought into the module via the `protobuf()` configuration scope, as opposed to
+     * being declared in the module's own source set.
+     *
+     * @see <a href="https://github.com/SpineEventEngine/core-jvm-compiler/issues/33">Issue #33</a>
+     */
+    @Test
+    fun `generate rejections from a 'protobuf()'-scoped dependency`() {
+        // As defined in `resources/.../proto-dependency/.../dependency_rejections.proto`,
+        // which `sub-module` consumes via `protobuf(project(":proto-dependency"))`.
+        val packageDir = targetMainDir().resolve(java)
+            .resolve("io/spine/sample/rejections/dependency")
+        assertExists(packageDir)
+        assertJavaFileExists(packageDir, "RejectionFromDependency")
     }
 }
 

--- a/signal/src/test/kotlin/io/spine/tools/core/jvm/signal/rejection/RejectionCodegenIgTest.kt
+++ b/signal/src/test/kotlin/io/spine/tools/core/jvm/signal/rejection/RejectionCodegenIgTest.kt
@@ -220,8 +220,6 @@ internal class RejectionCodegenIgTest {
      * Verifies that rejection throwables are generated for `rejections.proto` files
      * brought into the module via the `protobuf()` configuration scope, as opposed to
      * being declared in the module's own source set.
-     *
-     * @see <a href="https://github.com/SpineEventEngine/core-jvm-compiler/issues/33">Issue #33</a>
      */
     @Test
     fun `generate rejections from a 'protobuf()'-scoped dependency`() {

--- a/signal/src/test/resources/rejection-codegen-test/build.gradle.kts
+++ b/signal/src/test/resources/rejection-codegen-test/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,13 +66,21 @@ subprojects {
     val enclosingRootDir: String by extra
     apply {
         plugin("com.google.protobuf")
-        plugin("io.spine.core-jvm")
         from("${enclosingRootDir}/version.gradle.kts")
     }
 
     repositories.standardToSpineSdk()
 
-    dependencies {
-        implementation(Base.lib)
+    // The `proto-dependency` module emulates a shared, proto-only module. It only exposes its
+    // Protobuf sources (via the Protobuf Gradle plugin) so that they can be consumed through the
+    // `protobuf()` configuration scope. It deliberately does not apply the CoreJvm Compiler, so
+    // that it neither runs code generation itself nor exports the well-known and Spine option
+    // types to its consumers (which would clash with the consumer's own copies). See issue #33.
+    if (name != "proto-dependency") {
+        apply(plugin = "io.spine.core-jvm")
+
+        dependencies {
+            implementation(Base.lib)
+        }
     }
 }

--- a/signal/src/test/resources/rejection-codegen-test/build.gradle.kts
+++ b/signal/src/test/resources/rejection-codegen-test/build.gradle.kts
@@ -75,7 +75,7 @@ subprojects {
     // Protobuf sources (via the Protobuf Gradle plugin) so that they can be consumed through the
     // `protobuf()` configuration scope. It deliberately does not apply the CoreJvm Compiler, so
     // that it neither runs code generation itself nor exports the well-known and Spine option
-    // types to its consumers (which would clash with the consumer's own copies). See issue #33.
+    // types to its consumers (which would clash with the consumer's own copies).
     if (name != "proto-dependency") {
         apply(plugin = "io.spine.core-jvm")
 

--- a/signal/src/test/resources/rejection-codegen-test/proto-dependency/build.gradle.kts
+++ b/signal/src/test/resources/rejection-codegen-test/proto-dependency/build.gradle.kts
@@ -24,39 +24,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.protobuf.gradle.ProtobufExtension
 import io.spine.dependency.lib.Protobuf
-import io.spine.dependency.local.Base
-import io.spine.dependency.local.Validation
-import org.gradle.api.tasks.JavaExec
 
-plugins {
-    `java-test-fixtures`
+// A shared, proto-only module. It only declares Protobuf types and is consumed by `sub-module`
+// through the `protobuf()` configuration scope. The `java` and `com.google.protobuf` plugins are
+// applied by the root `subprojects` block. Unlike the other modules, it does not apply the
+// `io.spine.core-jvm` plugin, so that it stays a plain Protobuf producer and does not export the
+// well-known or Spine option types to its consumers. See issue #33.
+
+// Configure the `protoc` executable, which the `io.spine.core-jvm` plugin would otherwise set up.
+configure<ProtobufExtension> {
+    protoc {
+        artifact = Protobuf.compiler
+    }
 }
 
 dependencies {
-    // Bring the Protobuf definitions of the shared, proto-only module into this module
-    // via the `protobuf()` configuration scope. The rejection throwables for the types
-    // declared there are expected to be generated in this module. See issue #33.
-    protobuf(project(":proto-dependency"))
-
-    // Add Validation Java Runtime because the generated code reference
-    // the `ValidatingBuilder` interface even if validation codegen is turned off.
-    implementation(Validation.runtime)
-
-    Protobuf.libs.forEach {
-        testFixturesImplementation(it)
-    }
-    testFixturesImplementation(Base.lib)
-    testFixturesImplementation(Validation.runtime)
-}
-
-tasks.processResources.get().duplicatesStrategy = DuplicatesStrategy.INCLUDE
-
-tasks.findByName("launchSpineCompiler")?.apply { this as JavaExec
-    debugOptions {
-        enabled.set(false) // Set this option to `true` to enable remote debugging.
-        port.set(5566)
-        server.set(true)
-        suspend.set(true)
-    }
+    // The Protobuf runtime is needed to compile the Java code generated from this module's
+    // own `.proto` file. Spine Base is intentionally not used here (see the note above).
+    implementation(Protobuf.javaLib)
 }

--- a/signal/src/test/resources/rejection-codegen-test/proto-dependency/build.gradle.kts
+++ b/signal/src/test/resources/rejection-codegen-test/proto-dependency/build.gradle.kts
@@ -31,7 +31,7 @@ import io.spine.dependency.lib.Protobuf
 // through the `protobuf()` configuration scope. The `java` and `com.google.protobuf` plugins are
 // applied by the root `subprojects` block. Unlike the other modules, it does not apply the
 // `io.spine.core-jvm` plugin, so that it stays a plain Protobuf producer and does not export the
-// well-known or Spine option types to its consumers. See issue #33.
+// well-known or Spine option types to its consumers (which would clash with the consumer's own).
 
 // Configure the `protoc` executable, which the `io.spine.core-jvm` plugin would otherwise set up.
 configure<ProtobufExtension> {

--- a/signal/src/test/resources/rejection-codegen-test/proto-dependency/src/main/proto/dependency_rejections.proto
+++ b/signal/src/test/resources/rejection-codegen-test/proto-dependency/src/main/proto/dependency_rejections.proto
@@ -33,8 +33,8 @@ option java_multiple_files = false;
 // Do not specify `java_outer_classname` so that the outer class name is derived from the file name.
 
 // This file emulates a shared, proto-only module that is brought into a consuming module
-// via the `protobuf()` configuration scope (see issue #33). The consuming module
-// (`sub-module`) is expected to generate the rejection throwable for the type declared here.
+// via the `protobuf()` configuration scope. The consuming module (`sub-module`) is expected
+// to generate the rejection throwable for the type declared here.
 
 message RejectionFromDependency {
     string id = 1;

--- a/signal/src/test/resources/rejection-codegen-test/proto-dependency/src/main/proto/dependency_rejections.proto
+++ b/signal/src/test/resources/rejection-codegen-test/proto-dependency/src/main/proto/dependency_rejections.proto
@@ -24,39 +24,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import io.spine.dependency.lib.Protobuf
-import io.spine.dependency.local.Base
-import io.spine.dependency.local.Validation
-import org.gradle.api.tasks.JavaExec
+syntax = "proto3";
 
-plugins {
-    `java-test-fixtures`
-}
+package spine.sample.rejections.dependency;
 
-dependencies {
-    // Bring the Protobuf definitions of the shared, proto-only module into this module
-    // via the `protobuf()` configuration scope. The rejection throwables for the types
-    // declared there are expected to be generated in this module. See issue #33.
-    protobuf(project(":proto-dependency"))
+option java_package = "io.spine.sample.rejections.dependency";
+option java_multiple_files = false;
+// Do not specify `java_outer_classname` so that the outer class name is derived from the file name.
 
-    // Add Validation Java Runtime because the generated code reference
-    // the `ValidatingBuilder` interface even if validation codegen is turned off.
-    implementation(Validation.runtime)
+// This file emulates a shared, proto-only module that is brought into a consuming module
+// via the `protobuf()` configuration scope (see issue #33). The consuming module
+// (`sub-module`) is expected to generate the rejection throwable for the type declared here.
 
-    Protobuf.libs.forEach {
-        testFixturesImplementation(it)
-    }
-    testFixturesImplementation(Base.lib)
-    testFixturesImplementation(Validation.runtime)
-}
-
-tasks.processResources.get().duplicatesStrategy = DuplicatesStrategy.INCLUDE
-
-tasks.findByName("launchSpineCompiler")?.apply { this as JavaExec
-    debugOptions {
-        enabled.set(false) // Set this option to `true` to enable remote debugging.
-        port.set(5566)
-        server.set(true)
-        suspend.set(true)
-    }
+message RejectionFromDependency {
+    string id = 1;
 }

--- a/signal/src/test/resources/rejection-codegen-test/settings.gradle.kts
+++ b/signal/src/test/resources/rejection-codegen-test/settings.gradle.kts
@@ -1,11 +1,11 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -27,5 +27,6 @@
 rootProject.name = "rejection-gen-test"
 
 include(
+    "proto-dependency",
     "sub-module"
 )

--- a/signal/src/test/resources/rejection-codegen-test/sub-module/build.gradle.kts
+++ b/signal/src/test/resources/rejection-codegen-test/sub-module/build.gradle.kts
@@ -36,7 +36,8 @@ plugins {
 dependencies {
     // Bring the Protobuf definitions of the shared, proto-only module into this module
     // via the `protobuf()` configuration scope. The rejection throwables for the types
-    // declared there are expected to be generated in this module. See issue #33.
+    // declared there are expected to be generated in this module, exactly as if the
+    // `rejections.proto` had been declared in this module's own source set.
     protobuf(project(":proto-dependency"))
 
     // Add Validation Java Runtime because the generated code reference

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,5 +29,5 @@
  *
  * Do not rename this property, as it is also used in the integration tests via its name.
  */
-val coreJvmCompilerVersion by extra("2.0.0-SNAPSHOT.073")
+val coreJvmCompilerVersion by extra("2.0.0-SNAPSHOT.074")
 val versionToPublish by extra(coreJvmCompilerVersion)


### PR DESCRIPTION
## Summary

Resolves #33 — verification and regression coverage.

Issue #33 (filed in 2021 against the old protoc-based `RejectionGenPlugin`) reported that rejection throwables were generated only from `rejections.proto` files declared in a module's **own** source set. Rejections brought into a module from a shared, proto-only module via the `protobuf()` configuration scope were ignored — even though other signals (e.g. events) worked fine.

### Status in the current architecture

The plugin has since been rewritten on top of the Spine Compiler. In this architecture `RThrowableRenderer` renders a throwable for **every** `ProtobufSourceFile` in the compilation — i.e. every `*rejections.proto` that `protoc` compiled into the module, regardless of which module originally declared it. The `ast` model distinguishes a `ProtobufSourceFile` (a *compiled* source file) from a `ProtobufDependency` (an imported dependency), and the renderer iterates the former with no module filter.

Protos pulled in through the `protobuf()` scope are compiled into the consuming module (they land in protoc's `file_to_generate`), so they become `ProtobufSourceFile`s and their throwables are generated as expected. 

**The reported bug no longer reproduces.**

### What this PR adds

A regression test that pins the behavior down so it cannot silently regress:

- `rejection-codegen-test` gains a proto-only `proto-dependency` module that declares `dependency_rejections.proto` and applies only the Protobuf Gradle plugin (not the CoreJvm Compiler), emulating a shared proto-only module.
- `sub-module` consumes it via `protobuf(project(":proto-dependency"))`.
- `RejectionCodegenIgTest` asserts that the throwable for the dependency's rejection (`RejectionFromDependency`) is generated in the **consuming** module's `main` output.

No production code changes — this PR is verification plus a regression guard.

### Verification

`./gradlew :signal:test --tests "*RejectionCodegenIgTest"` → **6 tests, all green** (the 5 pre-existing assertions plus the new `protobuf()`-scoped one). Run against locally published artifacts.

https://claude.ai/code/session_01X3PSjC4zicZWChmDyEidYu

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3PSjC4zicZWChmDyEidYu)_