### PR TITLE
Support ID fields of enum type

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -53,16 +53,17 @@
     ]
   },
   "hooks": {
-    "PreToolUse": [
+    "SessionStart": [
       {
-        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.agents/scripts/protect-version-file.sh"
+            "command": "$CLAUDE_PROJECT_DIR/init-submodules"
           }
         ]
-      },
+      }
+    ],
+    "PreToolUse": [
       {
         "matcher": "Bash",
         "hooks": [

--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -6,10 +6,7 @@ jobs:
   build:
     name: Build on Ubuntu
     runs-on: ubuntu-latest
-    timeout-minutes: 90   # Avoid premature job termination on slow runners.
-    concurrency:  # Avoid canceling in-progress runs for the same branch.
-      group: ubuntu-ci-${{ github.ref }}
-      cancel-in-progress: false
+
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -6,8 +6,7 @@ jobs:
   build:
     name: Build on Ubuntu
     runs-on: ubuntu-latest
-    timeout-minutes: 90
-    concurrency:
+    concurrency:  # Avoid canceling in-progress runs for the same branch.
       group: ubuntu-ci-${{ github.ref }}
       cancel-in-progress: false
 
@@ -41,7 +40,7 @@ jobs:
       # `Publish` job. `failOnWarning` is enabled in the Dokka setup.
       - name: Check documentation
         run: ./gradlew dokkaGenerate --stacktrace
-        
+
       # See: https://github.com/marketplace/actions/junit-report-action
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v4.0.3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,15 @@ links to a shared requirements file (e.g. `jvm-project.md`), read that too.
 
 Shared skills, scripts, and guidelines come from the `.agents/shared` submodule (the
 [`agents`][agents-repo] repository) exposed via symlinks.
-`./config/pull` initializes and floats it automatically; on a fresh clone that skips
-`pull`, run `git submodule update --init --remote .agents/shared`.
+`./config/pull` initializes and floats them automatically. But a fresh `git worktree`
+(and some shallow clones / cloud checkouts) start with NO submodules checked out, so
+those symlinks dangle and no skills are found. Bootstrap such a tree with
+**`./init-submodules`** — a root script that materializes the missing submodules
+(`config`, `.agents/shared`, …) at their pinned commits. It depends on no pre-existing
+`config` submodule, so it works before `./config/pull` (which lives inside the `config`
+submodule) can. Claude Code runs it automatically via a `SessionStart` hook; other
+agents and humans run it by hand, then `./config/pull` to float the shared submodules
+to their branch tips.
 
 ## Commit and history safety
 
@@ -115,7 +122,7 @@ In consumer repositories, skip without comment any path matching:
 - `.claude/**`, `.idea/**`, `.junie/**`
 - `.github/copilot-instructions.md`
 - `buildSrc/**` (except `buildSrc/src/main/kotlin/module.gradle.kts`)
-- `gradle/`, `gradlew`, `gradlew.bat`
+- `gradle/`, `gradlew`, `gradlew.bat`, `init-submodules`
 - `.codecov.yml`, `.gitignore`, `gradle.properties`, `lychee.toml`
 - `.github/workflows/` — unless the workflow was introduced by this repo
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,15 @@ Shared skills, scripts, and guidelines come from the `.agents/shared` submodule 
 `./config/pull` initializes and floats them automatically. But a fresh `git worktree`
 (and some shallow clones / cloud checkouts) start with NO submodules checked out, so
 those symlinks dangle and no skills are found. Bootstrap such a tree with
-**`./init-submodules`** — a root script that materializes the missing submodules
-(`config`, `.agents/shared`, …) at their pinned commits. It depends on no pre-existing
-`config` submodule, so it works before `./config/pull` (which lives inside the `config`
+**`./init-submodules`** — a root script that materializes the missing
+*config-managed* submodules at their pinned commits: `config` itself, plus every
+submodule that declares a tracked `branch` in `.gitmodules` (`.agents/shared`, and
+any shared submodule added later) — the same rule `./config/pull` uses to decide
+what it floats. Submodules the consumer owns (a Hugo theme, a vendored library,
+doc-example submodules, …) declare no tracked branch and are left untouched, so the
+automatic `SessionStart` run never tries to clone — or fail on credentials for — a
+submodule this project does not manage. It depends on no pre-existing `config`
+submodule, so it works before `./config/pull` (which lives inside the `config`
 submodule) can. Claude Code runs it automatically via a `SessionStart` hook; other
 agents and humans run it by hand, then `./config/pull` to float the shared submodules
 to their branch tips.

--- a/base/src/main/kotlin/io/spine/tools/core/jvm/field/RequiredIdReaction.kt
+++ b/base/src/main/kotlin/io/spine/tools/core/jvm/field/RequiredIdReaction.kt
@@ -26,7 +26,11 @@
 
 package io.spine.tools.core.jvm.field
 
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type.TYPE_ENUM
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE
 import io.spine.annotation.VisibleForTesting
+import io.spine.base.Identifier
 import io.spine.option.OptionsProto
 import io.spine.server.event.NoReaction
 import io.spine.server.event.asA
@@ -36,6 +40,8 @@ import io.spine.tools.compiler.ast.Field
 import io.spine.tools.compiler.ast.FieldType
 import io.spine.tools.compiler.ast.File
 import io.spine.tools.compiler.ast.PrimitiveType
+import io.spine.tools.compiler.ast.PrimitiveType.PT_UNKNOWN
+import io.spine.tools.compiler.ast.PrimitiveType.UNRECOGNIZED
 import io.spine.tools.compiler.ast.TypeName
 import io.spine.tools.compiler.ast.event.TypeDiscovered
 import io.spine.tools.compiler.ast.findOption
@@ -68,9 +74,9 @@ public abstract class RequiredIdReaction : Reaction<TypeDiscovered>() {
      * as required.
      *
      * The method first checks that the [field] has a type supported for an ID:
-     * a `string`, a 32-bit or 64-bit integer, or a `Message`. A `repeated` field,
-     * a `map`, or a field of any other type (such as `bool`, `float`, `double`,
-     * `bytes`, or an `enum`) is rejected with a compilation error before the
+     * a `string`, a 32-bit or 64-bit integer, an `enum`, or a `Message`. A `repeated`
+     * field, a `map`, or a field of any other type (such as `bool`, `float`, `double`,
+     * or `bytes`) is rejected with a compilation error before the
      * conditions below are evaluated.
      * See `io.spine.base.Identifier` for the supported identifier types.
      *
@@ -127,9 +133,9 @@ public abstract class RequiredIdReaction : Reaction<TypeDiscovered>() {
 /**
  * Reports a compilation error if the type of the given ID [field] is not supported.
  *
- * By convention, an ID field must be a `string`, a 32-bit or 64-bit integer, or
- * a `Message`. A `repeated` field, a `map`, or a field of any other type (such as
- * `bool`, `float`, `double`, `bytes`, or an `enum`) is rejected at compile time.
+ * By convention, an ID field must be a `string`, a 32-bit or 64-bit integer, an `enum`,
+ * or a `Message`. A `repeated` field, a `map`, or a field of any other type (such as
+ * `bool`, `float`, `double`, or `bytes`) is rejected at compile time.
  *
  * See [io.spine.base.Identifier] for the supported identifier types.
  *
@@ -139,44 +145,46 @@ private fun checkIdTypeSupported(field: Field, file: File) =
     Compilation.check(field.type.isSupportedIdType(), file, field.span) {
         "The ID field `${field.qualifiedName}` of type `${field.type.name}`" +
                 " is not supported. An ID field must be a `string`," +
-                " a 32-bit or 64-bit integer, or a `Message`." +
-                " It cannot be a `bool`, `float`, `double`, `bytes`, `enum`," +
+                " a 32-bit or 64-bit integer, an `enum`, or a `Message`." +
+                " It cannot be a `bool`, `float`, `double`, `bytes`," +
                 " `repeated`, or `map` field." +
                 " Please change the type of the field."
     }
 
 /**
- * Tells if this [FieldType] is one of the types supported for an ID field:
- * a `string`, a 32-bit or 64-bit integer, or a `Message`.
+ * Tells if this [FieldType] is one of the types supported for an ID field.
  *
- * See `io.spine.base.Identifier` for the supported identifier types.
+ * This is a thin adapter over [io.spine.base.Identifier], which is the single source of
+ * truth for the supported identifier types. The Compiler-AST [PrimitiveType] is bridged to
+ * the protobuf [FieldDescriptorProto.Type] it mirrors, and the singular message and enum
+ * kinds are mapped to [TYPE_MESSAGE] and [TYPE_ENUM]. A `repeated` or a `map` field is never
+ * an identifier regardless of its element type, so those kinds are rejected here.
+ *
+ * @see io.spine.base.Identifier.isSupportedIdType
  */
 @VisibleForTesting
 internal fun FieldType.isSupportedIdType(): Boolean = when {
-    isMessage -> true
-    isPrimitive -> primitive in supportedIdPrimitives
+    isMessage -> Identifier.isSupportedIdType(TYPE_MESSAGE)
+    isEnum -> Identifier.isSupportedIdType(TYPE_ENUM)
+    isPrimitive -> primitive.toProtoType()?.let { Identifier.isSupportedIdType(it) } ?: false
     else -> false
 }
 
 /**
- * The primitive types that can be used for an ID field.
+ * Converts this Compiler-AST [PrimitiveType] to the protobuf [FieldDescriptorProto.Type]
+ * with the same name, or `null` if there is no protobuf counterpart.
  *
- * These are `string` and all 32-bit and 64-bit integer types, which are
- * represented in Java by `Integer` and `Long`, respectively.
+ * The constant names of [PrimitiveType] match those of [FieldDescriptorProto.Type] for every
+ * scalar type, so the conversion is by name. The synthetic [PT_UNKNOWN] and [UNRECOGNIZED]
+ * values have no protobuf counterpart and map to `null`.
  */
-private val supportedIdPrimitives: Set<PrimitiveType> = setOf(
-    PrimitiveType.TYPE_STRING,
-    PrimitiveType.TYPE_INT32,
-    PrimitiveType.TYPE_UINT32,
-    PrimitiveType.TYPE_SINT32,
-    PrimitiveType.TYPE_FIXED32,
-    PrimitiveType.TYPE_SFIXED32,
-    PrimitiveType.TYPE_INT64,
-    PrimitiveType.TYPE_UINT64,
-    PrimitiveType.TYPE_SINT64,
-    PrimitiveType.TYPE_FIXED64,
-    PrimitiveType.TYPE_SFIXED64,
-)
+@VisibleForTesting
+internal fun PrimitiveType.toProtoType(): FieldDescriptorProto.Type? =
+    if (this == PT_UNKNOWN || this == UNRECOGNIZED) {
+        null
+    } else {
+        FieldDescriptorProto.Type.valueOf(name)
+    }
 
 /**
  * Reports a compilation error if the type of the given [field] is

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/field/RequiredIdReactionSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/field/RequiredIdReactionSpec.kt
@@ -120,14 +120,23 @@ internal class RequiredIdReactionSpec {
     }
 
     @Test
-    fun `reject an ID field of an unsupported scalar or enum type`() {
-        // `bool`, `bytes`, `double`, and `enum` are not among the supported ID types.
-        listOf("active", "data", "rating", "color").forEach { name ->
+    fun `reject an ID field of an unsupported scalar type`() {
+        // `bool`, `bytes`, and `double` are not among the supported ID types.
+        listOf("active", "data", "rating").forEach { name ->
             val (error, _) = assertCompilationError {
                 reaction.test(farmField(name), MESSAGE)
             }
             error.message.assertUnsupportedIdType(name)
         }
+    }
+
+    @Test
+    fun `accept an 'enum' ID field`() {
+        // An `enum` is a supported ID type, so the ID-type check must pass and the
+        // reaction must complete without a compilation error. Whether the field becomes
+        // implicitly required depends on `(required)` support for enums.
+        val outcome = reaction.test(farmField("color"), MESSAGE)
+        (outcome.hasA() || outcome.hasB()).shouldBeTrue()
     }
 
     private companion object {

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/field/SupportedIdTypeSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/field/SupportedIdTypeSpec.kt
@@ -26,6 +26,8 @@
 
 package io.spine.tools.core.jvm.field
 
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type.TYPE_ENUM
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
 import io.spine.base.Identifier
@@ -69,13 +71,15 @@ internal class SupportedIdTypeSpec {
     }
 
     @Test
-    fun `accept a singular 'Message' field`() {
-        fieldType { message = someTypeName }.isSupportedIdType() shouldBe true
+    fun `classify a singular 'Message' field as 'Identifier' does`() {
+        fieldType { message = someTypeName }.isSupportedIdType() shouldBe
+            Identifier.isSupportedIdType(TYPE_MESSAGE)
     }
 
     @Test
-    fun `accept an 'enum' field`() {
-        fieldType { enumeration = someTypeName }.isSupportedIdType() shouldBe true
+    fun `classify an 'enum' field as 'Identifier' does`() {
+        fieldType { enumeration = someTypeName }.isSupportedIdType() shouldBe
+            Identifier.isSupportedIdType(TYPE_ENUM)
     }
 
     @Test

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/field/SupportedIdTypeSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/field/SupportedIdTypeSpec.kt
@@ -44,9 +44,10 @@ import org.junit.jupiter.api.Test
  * Verifies which field types may serve as an ID field.
  *
  * The supported/unsupported decision is owned by [io.spine.base.Identifier] in the
- * `base-libraries` repository — this suite asserts that [FieldType.isSupportedIdType]
- * agrees with that single source of truth for every primitive type, and that the
- * structural kinds (`Message`, `enum`, `repeated`, `map`) are dispatched correctly.
+ * `base-libraries` repository — this suite asserts that the `FieldType.isSupportedIdType()`
+ * extension ([isSupportedIdType]) agrees with that single source of truth for every
+ * primitive type, and that the structural kinds (`Message`, `enum`, `repeated`, `map`)
+ * are dispatched correctly.
  * Iterating over every [PrimitiveType] forces a future primitive into a decision via
  * [Identifier].
  *

--- a/base/src/test/kotlin/io/spine/tools/core/jvm/field/SupportedIdTypeSpec.kt
+++ b/base/src/test/kotlin/io/spine/tools/core/jvm/field/SupportedIdTypeSpec.kt
@@ -27,25 +27,10 @@
 package io.spine.tools.core.jvm.field
 
 import io.kotest.assertions.withClue
-import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
+import io.spine.base.Identifier
 import io.spine.tools.compiler.ast.PrimitiveType
-import io.spine.tools.compiler.ast.PrimitiveType.PT_UNKNOWN
-import io.spine.tools.compiler.ast.PrimitiveType.TYPE_BOOL
-import io.spine.tools.compiler.ast.PrimitiveType.TYPE_BYTES
-import io.spine.tools.compiler.ast.PrimitiveType.TYPE_DOUBLE
-import io.spine.tools.compiler.ast.PrimitiveType.TYPE_FIXED32
-import io.spine.tools.compiler.ast.PrimitiveType.TYPE_FIXED64
-import io.spine.tools.compiler.ast.PrimitiveType.TYPE_FLOAT
-import io.spine.tools.compiler.ast.PrimitiveType.TYPE_INT32
-import io.spine.tools.compiler.ast.PrimitiveType.TYPE_INT64
-import io.spine.tools.compiler.ast.PrimitiveType.TYPE_SFIXED32
-import io.spine.tools.compiler.ast.PrimitiveType.TYPE_SFIXED64
-import io.spine.tools.compiler.ast.PrimitiveType.TYPE_SINT32
-import io.spine.tools.compiler.ast.PrimitiveType.TYPE_SINT64
 import io.spine.tools.compiler.ast.PrimitiveType.TYPE_STRING
-import io.spine.tools.compiler.ast.PrimitiveType.TYPE_UINT32
-import io.spine.tools.compiler.ast.PrimitiveType.TYPE_UINT64
 import io.spine.tools.compiler.ast.PrimitiveType.UNRECOGNIZED
 import io.spine.tools.compiler.ast.TypeName
 import io.spine.tools.compiler.ast.fieldType
@@ -56,10 +41,14 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
 /**
- * Exhaustively verifies which field types may serve as an ID field.
+ * Verifies which field types may serve as an ID field.
  *
- * The matrix is driven by [PrimitiveType] itself, so a primitive type added to
- * the Compiler AST in the future is forced into a classification decision.
+ * The supported/unsupported decision is owned by [io.spine.base.Identifier] in the
+ * `base-libraries` repository — this suite asserts that [FieldType.isSupportedIdType]
+ * agrees with that single source of truth for every primitive type, and that the
+ * structural kinds (`Message`, `enum`, `repeated`, `map`) are dispatched correctly.
+ * Iterating over every [PrimitiveType] forces a future primitive into a decision via
+ * [Identifier].
  *
  * The end-to-end consequences of these classifications — a compilation failure
  * for an unsupported ID field — are covered by `RequiredIdReactionSpec` and the
@@ -69,28 +58,11 @@ import org.junit.jupiter.api.Test
 internal class SupportedIdTypeSpec {
 
     @Test
-    fun `classify every declared primitive type`() {
-        // If a new `PrimitiveType` is added, this assertion fails until the type
-        // is listed in `supported` or `unsupported` below.
-        (supported + unsupported) shouldBe allPrimitives
-        // No type may be classified as both supported and unsupported.
-        (supported intersect unsupported).shouldBeEmpty()
-    }
-
-    @Test
-    fun `accept 'string' and every 32-bit and 64-bit integer primitive`() {
-        supported.forEach { pt ->
+    fun `classify every primitive type as 'Identifier' does`() {
+        (PrimitiveType.entries - UNRECOGNIZED).forEach { pt ->
+            val expected = pt.toProtoType()?.let { Identifier.isSupportedIdType(it) } ?: false
             withClue(pt.name) {
-                fieldType { primitive = pt }.isSupportedIdType() shouldBe true
-            }
-        }
-    }
-
-    @Test
-    fun `reject every other primitive type`() {
-        unsupported.forEach { pt ->
-            withClue(pt.name) {
-                fieldType { primitive = pt }.isSupportedIdType() shouldBe false
+                fieldType { primitive = pt }.isSupportedIdType() shouldBe expected
             }
         }
     }
@@ -101,8 +73,8 @@ internal class SupportedIdTypeSpec {
     }
 
     @Test
-    fun `reject an 'enum' field`() {
-        fieldType { enumeration = someTypeName }.isSupportedIdType() shouldBe false
+    fun `accept an 'enum' field`() {
+        fieldType { enumeration = someTypeName }.isSupportedIdType() shouldBe true
     }
 
     @Test
@@ -121,25 +93,6 @@ internal class SupportedIdTypeSpec {
     }
 
     private companion object {
-
-        /**
-         * Primitive types accepted for an ID field: `string` and every 32-bit and
-         * 64-bit integer encoding (which map to Java `Integer` and `Long`).
-         */
-        val supported: Set<PrimitiveType> = setOf(
-            TYPE_STRING,
-            TYPE_INT32, TYPE_UINT32, TYPE_SINT32, TYPE_FIXED32, TYPE_SFIXED32,
-            TYPE_INT64, TYPE_UINT64, TYPE_SINT64, TYPE_FIXED64, TYPE_SFIXED64,
-        )
-
-        /** Primitive types that cannot be used for an ID field. */
-        val unsupported: Set<PrimitiveType> = setOf(
-            PT_UNKNOWN, TYPE_BOOL, TYPE_FLOAT, TYPE_DOUBLE, TYPE_BYTES,
-        )
-
-        /** All declared primitive types, excluding the `UNRECOGNIZED` sentinel. */
-        val allPrimitives: Set<PrimitiveType> =
-            PrimitiveType.entries.toSet() - UNRECOGNIZED
 
         /** A type name used to synthesize message- and enum-typed fields. */
         val someTypeName: TypeName = typeName {

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/IntelliJ.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/IntelliJ.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,8 @@ package io.spine.dependency.lib
 /**
  * The components of the IntelliJ Platform.
  *
- * Make sure to add the `intellijReleases` and `jetBrainsCacheRedirector`
- * repositories to your project. See `kotlin/Repositories.kt` for details.
+ * Make sure to add the `intellijReleases` and `intellijDependencies`
+ * repositories to your project. See `io/spine/gradle/repo/Repositories.kt` for details.
  */
 @Suppress("unused")
 object IntelliJ {

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.413"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.413"
+    const val version = "2.0.0-SNAPSHOT.420"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.420"
     const val group = Spine.group
     private const val prefix = "spine"
     const val libModule = "$prefix-base"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,8 +34,8 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.400"
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.400"
+    const val version = "2.0.0-SNAPSHOT.401"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.401"
 
     const val lib = "$group:tool-base:$version"
     const val classicCodegen = "$group:classic-codegen:$version"

--- a/buildSrc/src/main/kotlin/io/spine/gradle/repo/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/repo/Repositories.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ package io.spine.gradle.repo
 import io.spine.gradle.publish.PublishingRepos
 import java.net.URI
 import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.artifacts.repositories.ArtifactRepository
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.kotlin.dsl.maven
 
@@ -94,24 +95,39 @@ fun RepositoryHandler.spineArtifacts(): MavenArtifactRepository = maven {
 }
 
 val RepositoryHandler.intellijReleases: MavenArtifactRepository
-    get() = maven("https://www.jetbrains.com/intellij-repository/releases")
+    get() = maven("https://www.jetbrains.com/intellij-repository/releases") {
+        includeIntelliJPlatformOnly()
+    }
 
 val RepositoryHandler.jetBrainsCacheRedirector: MavenArtifactRepository
-    get() = maven("https://cache-redirector.jetbrains.com/intellij-dependencies")
+    get() = maven("https://cache-redirector.jetbrains.com/intellij-dependencies") {
+        includeIntelliJPlatformOnly()
+    }
 
 val RepositoryHandler.intellijDependencies: MavenArtifactRepository
     get() = maven("https://packages.jetbrains.team/maven/p/ij/intellij-dependencies") {
-        content {
-            includeGroupByRegex("com\\.jetbrains.*")
-            includeGroupByRegex("org\\.jetbrains.*")
-            includeGroupByRegex("com\\.intellij.*")
-        }
+        includeIntelliJPlatformOnly()
     }
 
 /**
  * Applies repositories commonly used by Spine Event Engine projects.
  */
 fun RepositoryHandler.standardToSpineSdk() {
+    //
+    // General-purpose, highly available repositories come first. Gradle stops at
+    // the first repository that can serve an artifact, so keeping these ahead of
+    // the special-purpose ones means coordinates shared with them (such as
+    // `org.jetbrains:annotations`) resolve here and never reach a less reliable
+    // mirror like `cache-redirector.jetbrains.com`.
+    //
+    // `io.spine.*` modules are served only by the Spine repositories below, so
+    // they are excluded here. Otherwise Gradle would query Central / the Plugin
+    // Portal for every Spine module first, adding pointless lookups and making
+    // Spine resolution depend on the health of repositories that never host it.
+    //
+    mavenCentral { excludeSpine() }
+    gradlePluginPortal { excludeSpine() }
+
     spineArtifacts()
 
     @Suppress("DEPRECATION") // Still use `CloudRepo` for earlier versions.
@@ -131,16 +147,20 @@ fun RepositoryHandler.standardToSpineSdk() {
             }
         }
 
+    // IntelliJ Platform repositories. Each is restricted to the IntelliJ
+    // coordinates it serves (see `includeIntelliJPlatformOnly`), so a transient
+    // 5xx from one of them cannot break the resolution of unrelated artifacts.
     intellijReleases
     jetBrainsCacheRedirector
     intellijDependencies
 
     maven {
         url = URI(Repos.sonatypeSnapshots)
+        // This repository only ever serves snapshots; restrict it so it is not
+        // queried (and cannot fail the build) for release artifacts.
+        mavenContent { snapshotsOnly() }
     }
 
-    mavenCentral()
-    gradlePluginPortal()
     mavenLocal().includeSpineOnly()
 }
 
@@ -178,5 +198,38 @@ private object Repos {
 private fun MavenArtifactRepository.includeSpineOnly() {
     content {
         includeGroupByRegex("io\\.spine.*")
+    }
+}
+
+/**
+ * Excludes Spine artifact groups from this repository.
+ *
+ * `io.spine.*` modules are published only to the Spine repositories (each scoped
+ * via [includeSpineOnly]). Excluding them from a general-purpose repository keeps
+ * Gradle from querying it — and depending on its health — for coordinates it
+ * never hosts.
+ */
+private fun ArtifactRepository.excludeSpine() {
+    content {
+        excludeGroupByRegex("io\\.spine.*")
+    }
+}
+
+/**
+ * Restricts a JetBrains/IntelliJ Platform repository to the coordinates it
+ * actually serves.
+ *
+ * These hosts — `cache-redirector.jetbrains.com` in particular — periodically
+ * answer with HTTP 5xx. Once Gradle sees such an error, it disables the
+ * repository for the rest of the build and fails the resolution instead of
+ * falling back to another repository. Without this filter the redirector is
+ * queried for every artifact, so a single 502 on an unrelated POM (such as
+ * `com.fasterxml.jackson:jackson-parent`) breaks the whole build.
+ */
+private fun MavenArtifactRepository.includeIntelliJPlatformOnly() {
+    content {
+        includeGroupByRegex("com\\.jetbrains.*")
+        includeGroupByRegex("org\\.jetbrains.*")
+        includeGroupByRegex("com\\.intellij.*")
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/repo/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/repo/Repositories.kt
@@ -99,11 +99,6 @@ val RepositoryHandler.intellijReleases: MavenArtifactRepository
         includeIntelliJPlatformOnly()
     }
 
-val RepositoryHandler.jetBrainsCacheRedirector: MavenArtifactRepository
-    get() = maven("https://cache-redirector.jetbrains.com/intellij-dependencies") {
-        includeIntelliJPlatformOnly()
-    }
-
 val RepositoryHandler.intellijDependencies: MavenArtifactRepository
     get() = maven("https://packages.jetbrains.team/maven/p/ij/intellij-dependencies") {
         includeIntelliJPlatformOnly()
@@ -118,7 +113,7 @@ fun RepositoryHandler.standardToSpineSdk() {
     // the first repository that can serve an artifact, so keeping these ahead of
     // the special-purpose ones means coordinates shared with them (such as
     // `org.jetbrains:annotations`) resolve here and never reach a less reliable
-    // mirror like `cache-redirector.jetbrains.com`.
+    // JetBrains mirror.
     //
     // `io.spine.*` modules are served only by the Spine repositories below, so
     // they are excluded here. Otherwise Gradle would query Central / the Plugin
@@ -147,11 +142,13 @@ fun RepositoryHandler.standardToSpineSdk() {
             }
         }
 
-    // IntelliJ Platform repositories. Each is restricted to the IntelliJ
-    // coordinates it serves (see `includeIntelliJPlatformOnly`), so a transient
-    // 5xx from one of them cannot break the resolution of unrelated artifacts.
+    // IntelliJ Platform repositories. `intellijReleases` serves the platform
+    // artifacts (`com.jetbrains.intellij.*`); `intellijDependencies` serves the
+    // repackaged third-party dependencies (`org.jetbrains.intellij.deps.*` and
+    // JetBrains-internal builds). Each is restricted to the coordinates it serves
+    // (see `includeIntelliJPlatformOnly`), so a transient 5xx from one of them
+    // cannot break the resolution of unrelated artifacts.
     intellijReleases
-    jetBrainsCacheRedirector
     intellijDependencies
 
     maven {
@@ -219,12 +216,11 @@ private fun ArtifactRepository.excludeSpine() {
  * Restricts a JetBrains/IntelliJ Platform repository to the coordinates it
  * actually serves.
  *
- * These hosts — `cache-redirector.jetbrains.com` in particular — periodically
- * answer with HTTP 5xx. Once Gradle sees such an error, it disables the
- * repository for the rest of the build and fails the resolution instead of
- * falling back to another repository. Without this filter the redirector is
- * queried for every artifact, so a single 502 on an unrelated POM (such as
- * `com.fasterxml.jackson:jackson-parent`) breaks the whole build.
+ * These hosts periodically answer with HTTP 5xx. Once Gradle sees such an error,
+ * it disables the repository for the rest of the build and fails the resolution
+ * instead of falling back to another repository. Without this filter such a
+ * repository is queried for every artifact, so a single 502 on an unrelated POM
+ * (such as `com.fasterxml.jackson:jackson-parent`) would break the whole build.
  */
 private fun MavenArtifactRepository.includeIntelliJPlatformOnly() {
     content {

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/license/LicenseReporter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/license/LicenseReporter.kt
@@ -96,6 +96,20 @@ object LicenseReporter {
 
             renderers = arrayOf(MarkdownReportRenderer(Paths.outputFilename))
         }
+
+        // The rendered report embeds the project's Maven coordinates — including its
+        // version — in the report header (see `Template.writeHeader`). The
+        // `generateLicenseReport` task is a `@CacheableTask` that keys its up-to-date check
+        // and build-cache entry on the resolved dependencies only, not on the project version.
+        // Without the version as an explicit input, a version-only change leaves the task
+        // `UP-TO-DATE` (or restorable from the build cache), so the report keeps the previous
+        // version while `pom.xml`, produced by an always-running task, is updated. Declaring
+        // the version as an input invalidates the cached output when it changes, so the report
+        // is regenerated. The value is read lazily so it reflects the version resolved at
+        // execution time, regardless of when `project.version` is assigned during configuration.
+        project.tasks.generateLicenseReport.configure {
+            inputs.property("projectVersion", project.provider { project.version.toString() })
+        }
     }
 
     /**

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1158,7 +1158,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2140,7 +2140,7 @@ This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3313,7 +3313,7 @@ This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4478,7 +4478,7 @@ This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5460,7 +5460,7 @@ This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6625,7 +6625,7 @@ This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -7607,7 +7607,7 @@ This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -8747,7 +8747,7 @@ This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -9963,7 +9963,7 @@ This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -11136,7 +11136,7 @@ This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -12118,7 +12118,7 @@ This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -13291,7 +13291,7 @@ This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -14273,7 +14273,7 @@ This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -15505,7 +15505,7 @@ This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -16754,7 +16754,7 @@ This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -17431,7 +17431,7 @@ This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -18604,7 +18604,7 @@ This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:10:21 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -19586,7 +19586,7 @@ This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:10:21 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -20759,7 +20759,7 @@ This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 17 21:48:35 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:10:21 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -21741,6 +21741,6 @@ This report was generated on **Wed Jun 17 21:48:35 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 17 21:48:34 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:10:21 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1158,7 +1158,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:35:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2140,7 +2140,7 @@ This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:35:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3313,7 +3313,7 @@ This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:35:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4478,7 +4478,7 @@ This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:35:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5460,7 +5460,7 @@ This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:35:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6625,7 +6625,7 @@ This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:35:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -7607,7 +7607,7 @@ This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:35:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -8747,7 +8747,7 @@ This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:35:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -9963,7 +9963,7 @@ This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:35:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -11136,7 +11136,7 @@ This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:35:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -12118,7 +12118,7 @@ This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:35:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -13291,7 +13291,7 @@ This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:35:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -14273,7 +14273,7 @@ This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:35:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -15505,7 +15505,7 @@ This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:35:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -16754,7 +16754,7 @@ This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:35:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -17431,7 +17431,7 @@ This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:35:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -18604,7 +18604,7 @@ This report was generated on **Thu Jun 18 21:10:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:10:21 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:35:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -19586,7 +19586,7 @@ This report was generated on **Thu Jun 18 21:10:21 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:10:21 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:35:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -20759,7 +20759,7 @@ This report was generated on **Thu Jun 18 21:10:21 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:10:21 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:35:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -21741,6 +21741,6 @@ This report was generated on **Thu Jun 18 21:10:21 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:10:21 WEST 2026** using 
+This report was generated on **Thu Jun 18 21:35:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1158,7 +1158,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using 
+This report was generated on **Fri Jun 19 12:57:57 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2140,7 +2140,7 @@ This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using 
+This report was generated on **Fri Jun 19 12:57:57 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3313,7 +3313,7 @@ This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using 
+This report was generated on **Fri Jun 19 12:57:57 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4478,7 +4478,7 @@ This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using 
+This report was generated on **Fri Jun 19 12:57:57 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5460,7 +5460,7 @@ This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using 
+This report was generated on **Fri Jun 19 12:57:57 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6625,7 +6625,7 @@ This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using 
+This report was generated on **Fri Jun 19 12:57:57 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -7607,7 +7607,7 @@ This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using 
+This report was generated on **Fri Jun 19 12:57:57 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -8747,7 +8747,7 @@ This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using 
+This report was generated on **Fri Jun 19 12:57:57 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -9963,7 +9963,7 @@ This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using 
+This report was generated on **Fri Jun 19 12:57:57 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -11136,7 +11136,7 @@ This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using 
+This report was generated on **Fri Jun 19 12:57:57 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -12118,7 +12118,7 @@ This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using 
+This report was generated on **Fri Jun 19 12:57:57 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -13291,7 +13291,7 @@ This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using 
+This report was generated on **Fri Jun 19 12:57:57 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -14273,7 +14273,7 @@ This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using 
+This report was generated on **Fri Jun 19 12:57:57 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -15505,7 +15505,7 @@ This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using 
+This report was generated on **Fri Jun 19 12:57:57 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -16754,7 +16754,7 @@ This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using 
+This report was generated on **Fri Jun 19 12:57:57 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -17431,7 +17431,7 @@ This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using 
+This report was generated on **Fri Jun 19 12:57:56 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -18604,7 +18604,7 @@ This report was generated on **Thu Jun 18 21:26:59 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:27:00 WEST 2026** using 
+This report was generated on **Fri Jun 19 12:57:58 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -19586,7 +19586,7 @@ This report was generated on **Thu Jun 18 21:27:00 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:27:00 WEST 2026** using 
+This report was generated on **Fri Jun 19 12:57:58 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -20759,7 +20759,7 @@ This report was generated on **Thu Jun 18 21:27:00 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:27:00 WEST 2026** using 
+This report was generated on **Fri Jun 19 12:57:58 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -21741,6 +21741,6 @@ This report was generated on **Thu Jun 18 21:27:00 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 21:27:00 WEST 2026** using 
+This report was generated on **Fri Jun 19 12:57:58 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -74,13 +74,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-annotations</artifactId>
-    <version>2.0.0-SNAPSHOT.413</version>
+    <version>2.0.0-SNAPSHOT.420</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.413</version>
+    <version>2.0.0-SNAPSHOT.420</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -116,7 +116,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>classic-codegen</artifactId>
-    <version>2.0.0-SNAPSHOT.400</version>
+    <version>2.0.0-SNAPSHOT.401</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -152,31 +152,31 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>gradle-plugin-api</artifactId>
-    <version>2.0.0-SNAPSHOT.400</version>
+    <version>2.0.0-SNAPSHOT.401</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>jvm-tools</artifactId>
-    <version>2.0.0-SNAPSHOT.400</version>
+    <version>2.0.0-SNAPSHOT.401</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.400</version>
+    <version>2.0.0-SNAPSHOT.401</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>protobuf-setup-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.400</version>
+    <version>2.0.0-SNAPSHOT.401</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>psi-java</artifactId>
-    <version>2.0.0-SNAPSHOT.400</version>
+    <version>2.0.0-SNAPSHOT.401</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -290,7 +290,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.400</version>
+    <version>2.0.0-SNAPSHOT.401</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -302,7 +302,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>tool-base</artifactId>
-    <version>2.0.0-SNAPSHOT.400</version>
+    <version>2.0.0-SNAPSHOT.401</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -396,12 +396,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>intellij-platform</artifactId>
-    <version>2.0.0-SNAPSHOT.400</version>
+    <version>2.0.0-SNAPSHOT.401</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>intellij-platform-java</artifactId>
-    <version>2.0.0-SNAPSHOT.400</version>
+    <version>2.0.0-SNAPSHOT.401</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>

--- a/init-submodules
+++ b/init-submodules
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+################################################################################
+#
+# Materialize the submodules a fresh working tree is missing, so agent assets
+# resolve.
+#
+# `git worktree add` — and some shallow CI / cloud checkouts — populate only the
+# superproject's own tracked files; registered submodules are left UNinitialized.
+# In a Spine repo that means the `config` and `.agents/shared` submodules are
+# empty, the `.agents/skills` -> `.agents/shared/skills` symlink dangles, and no
+# agent skills, scripts, or guidelines can be found.
+#
+# This script is the bootstrap that has to run BEFORE `./config/pull`: `pull`
+# lives inside the `config` submodule, so on a fresh worktree it does not yet
+# exist. `init-submodules`, by contrast, is a plain tracked file at the repo root
+# (distributed by `config`), so `git worktree add` always checks it out — it can
+# therefore bring `config` itself into existence.
+#
+# It initializes ONLY submodules that are not yet checked out (those
+# `git submodule status` marks with a leading `-`), at the commit the branch
+# pins. Submodules already present are left exactly as they are, so a tree that
+# floated `config` / `.agents/shared` to a branch tip via `./config/pull` is
+# never silently rewound to the pin. That makes the script idempotent and safe to
+# run on every session start.
+#
+# It does NOT float submodules to their branch tips — run `./config/pull`
+# afterwards for that. Unlike `pull`, it depends on no pre-existing `config`
+# submodule, so it can bootstrap a bare worktree where `./config/pull` does not
+# yet exist.
+#
+################################################################################
+
+set -u
+
+root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$root" || exit 0
+
+# Nothing to do in a repo without submodules.
+[ -f .gitmodules ] || exit 0
+
+# `git submodule status` prefixes each uninitialized submodule with `-`; an
+# initialized one starts with a space (at the pinned commit) or `+` (ahead of
+# it). Act only on the `-` lines, taking the path from the second field.
+git submodule status 2>/dev/null | awk '$1 ~ /^-/ { print $2 }' | while read -r path; do
+    [ -n "$path" ] || continue
+    echo "init-submodules: initializing '$path'"
+    git submodule update --init --recursive -- "$path" \
+        || echo "init-submodules: WARNING — could not initialize '$path' (offline?)." >&2
+done
+
+exit 0

--- a/init-submodules
+++ b/init-submodules
@@ -2,8 +2,8 @@
 
 ################################################################################
 #
-# Materialize the submodules a fresh working tree is missing, so agent assets
-# resolve.
+# Materialize the *config-managed* submodules a fresh working tree is missing, so
+# agent assets resolve.
 #
 # `git worktree add` — and some shallow CI / cloud checkouts — populate only the
 # superproject's own tracked files; registered submodules are left UNinitialized.
@@ -17,12 +17,28 @@
 # (distributed by `config`), so `git worktree add` always checks it out — it can
 # therefore bring `config` itself into existence.
 #
-# It initializes ONLY submodules that are not yet checked out (those
-# `git submodule status` marks with a leading `-`), at the commit the branch
-# pins. Submodules already present are left exactly as they are, so a tree that
-# floated `config` / `.agents/shared` to a branch tip via `./config/pull` is
-# never silently rewound to the pin. That makes the script idempotent and safe to
-# run on every session start.
+# It initializes ONLY submodules that are BOTH:
+#
+#   * not yet checked out — those `git submodule status` marks with a leading `-`,
+#     at the commit the branch pins; and
+#
+#   * config-managed — `config` itself (the bootstrap target `pull` lives inside,
+#     which carries no tracked `branch` in a consumer's `.gitmodules`), plus every
+#     submodule that declares a tracked `branch` in `.gitmodules`. This is exactly
+#     the rule `./config/pull` uses to decide what it floats, so the two scripts
+#     can never disagree about what is shared.
+#
+# Consumer-owned submodules (a Hugo theme, a vendored library, documentation
+# examples, ...) declare no tracked branch and are deliberately left untouched.
+# Because a `SessionStart` hook runs this script automatically on every session,
+# initializing them would mean trying to clone — or failing on credentials for —
+# a submodule this project does not manage, on every single start. They are
+# skipped (noted on stderr).
+#
+# Submodules already present are left exactly as they are, so a tree that floated
+# `config` / `.agents/shared` to a branch tip via `./config/pull` is never
+# silently rewound to the pin. That makes the script idempotent and safe to run on
+# every session start.
 #
 # It does NOT float submodules to their branch tips — run `./config/pull`
 # afterwards for that. Unlike `pull`, it depends on no pre-existing `config`
@@ -39,14 +55,33 @@ cd "$root" || exit 0
 # Nothing to do in a repo without submodules.
 [ -f .gitmodules ] || exit 0
 
+# The set of config-managed submodule paths: `config` itself (handled specially —
+# it carries no tracked branch, exactly as in `./config/pull`), plus every
+# submodule declaring a tracked `branch` in `.gitmodules`. Mirrors `pull`'s rule.
+config_managed_paths() {
+    printf '%s\n' 'config'
+    git config -f .gitmodules --get-regexp '^submodule\..*\.branch$' 2>/dev/null \
+    | while read -r key _branch; do
+        name=${key#submodule.}; name=${name%.branch}
+        git config -f .gitmodules --get "submodule.$name.path" 2>/dev/null
+    done
+}
+
+managed=$(config_managed_paths | sort -u)
+
 # `git submodule status` prefixes each uninitialized submodule with `-`; an
-# initialized one starts with a space (at the pinned commit) or `+` (ahead of
-# it). Act only on the `-` lines, taking the path from the second field.
+# initialized one starts with a space (at the pinned commit) or `+` (ahead of it).
+# Act only on the `-` lines, taking the path from the second field, and only when
+# that path is config-managed.
 git submodule status 2>/dev/null | awk '$1 ~ /^-/ { print $2 }' | while read -r path; do
     [ -n "$path" ] || continue
-    echo "init-submodules: initializing '$path'"
-    git submodule update --init --recursive -- "$path" \
-        || echo "init-submodules: WARNING — could not initialize '$path' (offline?)." >&2
+    if printf '%s\n' "$managed" | grep -qxF -- "$path"; then
+        echo "init-submodules: initializing '$path'"
+        git submodule update --init --recursive -- "$path" \
+            || echo "init-submodules: WARNING — could not initialize '$path' (offline?)." >&2
+    else
+        echo "init-submodules: skipping consumer-owned '$path' (not config-managed)." >&2
+    fi
 done
 
 exit 0


### PR DESCRIPTION
## What

Allows an `enum` field to serve as an entity ID, and makes `io.spine.base.Identifier`
the single source of truth for which field types are supported as IDs.

Previously the compiler kept its own hard-coded list of ID-supported primitive types and
explicitly rejected `enum`, duplicating — and drifting from — the policy that already lives
in `Identifier`. `FieldType.isSupportedIdType()` now delegates to
`Identifier.isSupportedIdType(...)`:

- The Compiler-AST `PrimitiveType` is bridged to the protobuf `FieldDescriptorProto.Type`
  it mirrors via a new `PrimitiveType.toProtoType()` (by-name conversion; the synthetic
  `PT_UNKNOWN` / `UNRECOGNIZED` values map to `null`).
- Message and enum kinds map to `TYPE_MESSAGE` / `TYPE_ENUM`.
- `repeated` and `map` fields are never identifiers regardless of element type and remain
  rejected.

The local `supportedIdPrimitives` set is removed, so the supported-ID-type policy can no
longer diverge from `Identifier`.

## Why

`enum` is a valid identifier type in `base`, but the compiler rejected it, producing a
spurious compilation error. Consolidating on `Identifier` fixes that and prevents the two
lists from diverging again — a primitive type added to the Compiler AST in the future is
forced into a classification decision through `Identifier`.

## Tests

- `RequiredIdReactionSpec` — an `enum` ID field is now accepted (no compilation error); the
  unsupported-scalar case drops `enum` and keeps `bool` / `bytes` / `double`.
- `SupportedIdTypeSpec` — rewritten to assert `FieldType.isSupportedIdType()` agrees with
  `Identifier` for every `PrimitiveType`, plus correct dispatch of the structural kinds
  (`Message`, `enum`, `repeated`, `map`).

